### PR TITLE
feat: Add resolvedPcbStyle support to override silkscreen font size

### DIFF
--- a/src/convert-kicad-json-to-tscircuit-soup.ts
+++ b/src/convert-kicad-json-to-tscircuit-soup.ts
@@ -80,8 +80,13 @@ export const convertKicadLayerToTscircuitLayer = (kicadLayer: string) => {
   }
 }
 
+export interface ResolvedPcbStyle {
+  silkscreenFontSize?: number
+}
+
 export const convertKicadJsonToTsCircuitSoup = async (
   kicadJson: KicadModJson,
+  options?: { resolvedPcbStyle?: ResolvedPcbStyle },
 ): Promise<AnyCircuitElement[]> => {
   const {
     fp_lines,
@@ -713,7 +718,10 @@ export const convertKicadJsonToTsCircuitSoup = async (
         type: "pcb_silkscreen_text",
         layer: layerRef,
         font: "tscircuit2024",
-        font_size: fp_text.effects?.font?.size[0] ?? 1,
+        font_size:
+          options?.resolvedPcbStyle?.silkscreenFontSize ??
+          fp_text.effects?.font?.size[0] ??
+          1,
         pcb_component_id,
         anchor_position: { x: fp_text.at[0], y: -fp_text.at[1] },
         anchor_alignment: "center",
@@ -746,7 +754,9 @@ export const convertKicadJsonToTsCircuitSoup = async (
     const propLayer = propFab!.attributes.layer?.toLowerCase()
     const isFabLayer = propLayer?.endsWith(".fab")
 
-    const font_size = getSilkscreenFontSizeFromFpTexts(fp_texts)
+    const font_size =
+      options?.resolvedPcbStyle?.silkscreenFontSize ??
+      getSilkscreenFontSizeFromFpTexts(fp_texts)
 
     circuitJson.push({
       type: isFabLayer ? "pcb_fabrication_note_text" : "pcb_silkscreen_text",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
-export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"
+export {
+  convertKicadJsonToTsCircuitSoup,
+  type ResolvedPcbStyle,
+} from "./convert-kicad-json-to-tscircuit-soup"

--- a/src/parse-kicad-mod-to-circuit-json.ts
+++ b/src/parse-kicad-mod-to-circuit-json.ts
@@ -1,12 +1,16 @@
 import type { AnyCircuitElement } from "circuit-json"
 import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
-import { convertKicadJsonToTsCircuitSoup as convertKicadJsonToCircuitJson } from "./convert-kicad-json-to-tscircuit-soup"
+import {
+  convertKicadJsonToTsCircuitSoup as convertKicadJsonToCircuitJson,
+  type ResolvedPcbStyle,
+} from "./convert-kicad-json-to-tscircuit-soup"
 
 export const parseKicadModToCircuitJson = async (
   kicadMod: string,
+  options?: { resolvedPcbStyle?: ResolvedPcbStyle },
 ): Promise<AnyCircuitElement[]> => {
   const kicadJson = parseKicadModToKicadJson(kicadMod)
 
-  const circuitJson = await convertKicadJsonToCircuitJson(kicadJson)
+  const circuitJson = await convertKicadJsonToCircuitJson(kicadJson, options)
   return circuitJson as any
 }

--- a/tests/resolved-pcb-style.test.ts
+++ b/tests/resolved-pcb-style.test.ts
@@ -1,0 +1,103 @@
+import { test } from "bun:test"
+import { expect } from "bun:test"
+import { convertKicadJsonToTsCircuitSoup } from "../src/convert-kicad-json-to-tscircuit-soup"
+import { parseKicadModToKicadJson } from "../src/parse-kicad-mod-to-kicad-json"
+
+test("resolvedPcbStyle.silkscreenFontSize overrides kicad silkscreen font size", async () => {
+  const kicadModContent = `(footprint "TEST_FOOTPRINT" (layer "F.Cu")
+  (attr smd)
+  (fp_text reference "REF**" (at 0 -1.17) (layer "F.SilkS")
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (fp_text value "TEST_VALUE" (at 0 1.17) (layer "F.SilkS")
+    (effects (font (size 0.8 0.8) (thickness 0.12)))
+  )
+  (pad "1" smd rect (at -0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask"))
+)`
+
+  const kicadJson = parseKicadModToKicadJson(kicadModContent)
+
+  // Convert without resolvedPcbStyle
+  const circuitJsonDefault = await convertKicadJsonToTsCircuitSoup(kicadJson)
+  const silkscreenTextsDefault = circuitJsonDefault.filter(
+    (el: any) => el.type === "pcb_silkscreen_text",
+  ) as any[]
+
+  // Verify default font sizes from kicad
+  expect(silkscreenTextsDefault[0].font_size).toBe(1)
+  expect(silkscreenTextsDefault[1].font_size).toBe(0.8)
+
+  // Convert with resolvedPcbStyle
+  const circuitJsonWithStyle = await convertKicadJsonToTsCircuitSoup(
+    kicadJson,
+    {
+      resolvedPcbStyle: {
+        silkscreenFontSize: 2.5,
+      },
+    },
+  )
+  const silkscreenTextsWithStyle = circuitJsonWithStyle.filter(
+    (el: any) => el.type === "pcb_silkscreen_text",
+  ) as any[]
+
+  // Verify all silkscreen texts use the overridden font size
+  expect(silkscreenTextsWithStyle[0].font_size).toBe(2.5)
+  expect(silkscreenTextsWithStyle[1].font_size).toBe(2.5)
+})
+
+test("resolvedPcbStyle.silkscreenFontSize does not affect fabrication text", async () => {
+  const kicadModContent = `(footprint "TEST_FOOTPRINT" (layer "F.Cu")
+  (attr smd)
+  (fp_text reference "REF**" (at 0 -1.17) (layer "F.SilkS")
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (fp_text value "TEST_VALUE" (at 0 1.17) (layer "F.Fab")
+    (effects (font (size 0.8 0.8) (thickness 0.12)))
+  )
+)`
+
+  const kicadJson = parseKicadModToKicadJson(kicadModContent)
+
+  // Convert with resolvedPcbStyle
+  const circuitJson = await convertKicadJsonToTsCircuitSoup(kicadJson, {
+    resolvedPcbStyle: {
+      silkscreenFontSize: 2.5,
+    },
+  })
+
+  const silkscreenTexts = circuitJson.filter(
+    (el: any) => el.type === "pcb_silkscreen_text",
+  ) as any[]
+  const fabTexts = circuitJson.filter(
+    (el: any) => el.type === "pcb_fabrication_note_text",
+  ) as any[]
+
+  // Silkscreen should use overridden size
+  expect(silkscreenTexts[0].font_size).toBe(2.5)
+
+  // Fabrication text should keep original size
+  expect(fabTexts[0].font_size).toBe(0.8)
+})
+
+test("resolvedPcbStyle with undefined silkscreenFontSize uses kicad defaults", async () => {
+  const kicadModContent = `(footprint "TEST_FOOTPRINT" (layer "F.Cu")
+  (attr smd)
+  (fp_text reference "REF**" (at 0 -1.17) (layer "F.SilkS")
+    (effects (font (size 1.5 1.5) (thickness 0.15)))
+  )
+)`
+
+  const kicadJson = parseKicadModToKicadJson(kicadModContent)
+
+  // Convert with empty resolvedPcbStyle
+  const circuitJson = await convertKicadJsonToTsCircuitSoup(kicadJson, {
+    resolvedPcbStyle: {},
+  })
+
+  const silkscreenTexts = circuitJson.filter(
+    (el: any) => el.type === "pcb_silkscreen_text",
+  ) as any[]
+
+  // Should use kicad default
+  expect(silkscreenTexts[0].font_size).toBe(1.5)
+})


### PR DESCRIPTION
## PR Description
This pull request adds support for `resolvedPcbStyle` parameter to allow external callers to override the silkscreen font size in KiCad footprint conversions.

### Changes
- Added `ResolvedPcbStyle` interface with optional `silkscreenFontSize` property
- Updated `convertKicadJsonToTsCircuitSoup`, which now accepts an optional `options` parameter with `resolvedPcbStyle`
- Updated `parseKicadModToCircuitJson` that forwards the options to the converter
- When `resolvedPcbStyle.silkscreenFontSize` is provided, it overrides the font size from KiCad's `fp_text` elements for silkscreen text (but not fabrication text)

### Tests Added
- Verifies font size override works correctly
- Verifies fabrication text is not affected
- Verifies undefined resolvedPcbStyle falls back to KiCad defaults