### PR TITLE
Handle courtyard rectangles from fp_rect and fp_line

### DIFF
--- a/src/convert-kicad-json-to-tscircuit-soup.ts
+++ b/src/convert-kicad-json-to-tscircuit-soup.ts
@@ -6,12 +6,12 @@ import type {
   PcbCourtyardOutline,
 } from "circuit-json"
 import Debug from "debug"
+import { getSilkscreenFontSizeFromFpTexts } from "./get-Silkscreen-Font-Size-From-Fp-Texts"
 import { generateArcPath, getArcLength } from "./math/arc-utils"
-import { makePoint } from "./math/make-point"
 import type { EdgeSegment } from "./math/edge-segment"
 import { findClosedPolygons } from "./math/find-closed-polygons"
+import { makePoint } from "./math/make-point"
 import { polygonToPoints } from "./math/polygon-to-points"
-import { getSilkscreenFontSizeFromFpTexts } from "./get-Silkscreen-Font-Size-From-Fp-Texts"
 
 const degToRad = (deg: number) => (deg * Math.PI) / 180
 const rotatePoint = (x: number, y: number, deg: number) => {
@@ -83,7 +83,7 @@ const normalizePortName = (name: string | number | undefined) => {
 
 const getPinNumber = (name: string | number | undefined) => {
   const normalized = normalizePortName(name)
-  const parsed = normalized !== undefined ? Number(normalized) : NaN
+  const parsed = normalized !== undefined ? Number(normalized) : Number.NaN
   return Number.isFinite(parsed) ? parsed : undefined
 }
 
@@ -561,10 +561,46 @@ export const convertKicadJsonToTsCircuitSoup = async (
     }
   }
 
+  let courtyardRectId = 0
+  let courtyardOutlineId = 0
+
+  if (fp_rects) {
+    for (const fp_rect of fp_rects) {
+      const lowerLayer = fp_rect.layer.toLowerCase()
+      if (!lowerLayer.endsWith(".crtyd")) {
+        continue
+      }
+      const layer = convertKicadLayerToTscircuitLayer(fp_rect.layer)
+      if (!layer) {
+        continue
+      }
+      const startX = fp_rect.start[0]
+      const startY = fp_rect.start[1]
+      const endX = fp_rect.end[0]
+      const endY = fp_rect.end[1]
+      const minX = Math.min(startX, endX)
+      const maxX = Math.max(startX, endX)
+      const minY = Math.min(startY, endY)
+      const maxY = Math.max(startY, endY)
+
+      circuitJson.push({
+        type: "pcb_courtyard_rect",
+        pcb_courtyard_rect_id: `pcb_courtyard_rect_${courtyardRectId++}`,
+        pcb_component_id,
+        layer,
+        center: {
+          x: (minX + maxX) / 2,
+          y: -((minY + maxY) / 2),
+        },
+        width: maxX - minX,
+        height: maxY - minY,
+      } as any)
+    }
+  }
+
   // Collect Edge.Cuts segments for closed polygon detection
   const edgeCutSegments: EdgeSegment[] = []
-  const frontCourtyardSegments: EdgeSegment[] = []
-  const backCourtyardSegments: EdgeSegment[] = []
+  const courtyardSegmentsByLayer = new Map<string, EdgeSegment[]>()
 
   for (const fp_line of fp_lines) {
     const lowerLayer = fp_line.layer.toLowerCase()
@@ -575,20 +611,15 @@ export const convertKicadJsonToTsCircuitSoup = async (
         end: { x: fp_line.end[0], y: fp_line.end[1] },
         strokeWidth: fp_line.stroke.width,
       })
-    } else if (lowerLayer === "f.crtyd") {
-      frontCourtyardSegments.push({
+    } else if (lowerLayer.endsWith(".crtyd")) {
+      const segments = courtyardSegmentsByLayer.get(lowerLayer) ?? []
+      segments.push({
         type: "line",
         start: { x: fp_line.start[0], y: fp_line.start[1] },
         end: { x: fp_line.end[0], y: fp_line.end[1] },
         strokeWidth: fp_line.stroke.width,
       })
-    } else if (lowerLayer === "b.crtyd") {
-      backCourtyardSegments.push({
-        type: "line",
-        start: { x: fp_line.start[0], y: fp_line.start[1] },
-        end: { x: fp_line.end[0], y: fp_line.end[1] },
-        strokeWidth: fp_line.stroke.width,
-      })
+      courtyardSegmentsByLayer.set(lowerLayer, segments)
     }
   }
 
@@ -602,22 +633,16 @@ export const convertKicadJsonToTsCircuitSoup = async (
         end: { x: fp_arc.end[0], y: fp_arc.end[1] },
         strokeWidth: fp_arc.stroke.width,
       })
-    } else if (lowerLayer === "f.crtyd") {
-      frontCourtyardSegments.push({
+    } else if (lowerLayer.endsWith(".crtyd")) {
+      const segments = courtyardSegmentsByLayer.get(lowerLayer) ?? []
+      segments.push({
         type: "arc",
         start: { x: fp_arc.start[0], y: fp_arc.start[1] },
         mid: { x: fp_arc.mid[0], y: fp_arc.mid[1] },
         end: { x: fp_arc.end[0], y: fp_arc.end[1] },
         strokeWidth: fp_arc.stroke.width,
       })
-    } else if (lowerLayer === "b.crtyd") {
-      backCourtyardSegments.push({
-        type: "arc",
-        start: { x: fp_arc.start[0], y: fp_arc.start[1] },
-        mid: { x: fp_arc.mid[0], y: fp_arc.mid[1] },
-        end: { x: fp_arc.end[0], y: fp_arc.end[1] },
-        strokeWidth: fp_arc.stroke.width,
-      })
+      courtyardSegmentsByLayer.set(lowerLayer, segments)
     }
   }
 
@@ -639,50 +664,44 @@ export const convertKicadJsonToTsCircuitSoup = async (
     }
   }
 
-  // Create pcb_courtyard_outline elements from courtyard segments
-  let courtyardOutlineId = 0
-  for (const [segments, layer] of [
-    [frontCourtyardSegments, "top"],
-    [backCourtyardSegments, "bottom"],
-  ] as const) {
-    const closedCourtyardPolygons = findClosedPolygons(segments)
-    for (const polygon of closedCourtyardPolygons) {
+  for (const [kicadLayer, segments] of courtyardSegmentsByLayer) {
+    const layer = convertKicadLayerToTscircuitLayer(kicadLayer)
+    if (!layer) {
+      continue
+    }
+    const courtyardPolygons = findClosedPolygons(segments)
+    for (const polygon of courtyardPolygons) {
       const points = polygonToPoints(polygon)
-      if (points.length >= 3) {
+      if (points.length < 2) {
+        continue
+      }
+      const rect = getAxisAlignedRectFromPoints(points)
+      if (rect) {
+        circuitJson.push({
+          type: "pcb_courtyard_rect",
+          pcb_courtyard_rect_id: `pcb_courtyard_rect_${courtyardRectId++}`,
+          pcb_component_id,
+          layer,
+          center: {
+            x: rect.x,
+            y: -rect.y,
+          },
+          width: rect.width,
+          height: rect.height,
+        } as any)
+      } else {
         circuitJson.push({
           type: "pcb_courtyard_outline",
           pcb_courtyard_outline_id: `pcb_courtyard_outline_${courtyardOutlineId++}`,
+          pcb_component_id,
           layer,
-          pcb_component_id,
-          outline: points.map((p) => ({ x: p.x, y: -p.y })),
+          outline: points.map((point) => ({ x: point.x, y: -point.y })),
+          stroke_width: 0.05,
+          is_closed: true,
         } as any)
       }
     }
   }
-
-  if (fp_rects) {
-    for (const fp_rect of fp_rects) {
-      const lowerLayer = fp_rect.layer.toLowerCase()
-      if (lowerLayer === "f.crtyd" || lowerLayer === "b.crtyd") {
-        const x1 = fp_rect.start[0]
-        const y1 = fp_rect.start[1]
-        const x2 = fp_rect.end[0]
-        const y2 = fp_rect.end[1]
-        circuitJson.push({
-          type: "pcb_courtyard_rect",
-          pcb_courtyard_rect_id: `pcb_courtyard_rect_${courtyardOutlineId++}`,
-          pcb_component_id,
-          layer: convertKicadLayerToTscircuitLayer(fp_rect.layer)!,
-          center: { x: (x1 + x2) / 2, y: -((y1 + y2) / 2) },
-          width: Math.abs(x2 - x1),
-          height: Math.abs(y2 - y1),
-        } as any)
-      } else {
-        debug("Unhandled layer for fp_rect", fp_rect.layer)
-      }
-    }
-  }
-
   let traceId = 0
   let silkPathId = 0
   let fabPathId = 0
@@ -784,7 +803,6 @@ export const convertKicadJsonToTsCircuitSoup = async (
               pushRoutePoint(point)
             }
           }
-          continue
         }
       }
       const routePoints = route

--- a/src/kicad-zod.ts
+++ b/src/kicad-zod.ts
@@ -192,29 +192,6 @@ export const fp_circle_def = z.object({
   uuid: z.string().optional(),
 })
 
-export const fp_poly_def = z
-  .object({
-    pts: z.array(fp_poly_point_def),
-    stroke: z
-      .object({
-        width: z.number(),
-        type: z.string(),
-      })
-      .optional(),
-    width: z.number().optional(),
-    layer: z.string(),
-    uuid: z.string().optional(),
-    fill: z.string().optional(),
-  })
-  // Old kicad versions don't have "stroke"
-  .transform((data) => {
-    return {
-      ...data,
-      width: undefined,
-      stroke: data.stroke ?? { width: data.width },
-    } as MakeRequired<Omit<typeof data, "width">, "stroke">
-  })
-
 export const fp_rect_def = z
   .object({
     start: point2,
@@ -230,6 +207,29 @@ export const fp_rect_def = z
     layer: z.string(),
     uuid: z.string().optional(),
   })
+  .transform((data) => {
+    return {
+      ...data,
+      width: undefined,
+      stroke: data.stroke ?? { width: data.width },
+    } as MakeRequired<Omit<typeof data, "width">, "stroke">
+  })
+
+export const fp_poly_def = z
+  .object({
+    pts: z.array(fp_poly_point_def),
+    stroke: z
+      .object({
+        width: z.number(),
+        type: z.string(),
+      })
+      .optional(),
+    width: z.number().optional(),
+    layer: z.string(),
+    uuid: z.string().optional(),
+    fill: z.string().optional(),
+  })
+  // Old kicad versions don't have "stroke"
   .transform((data) => {
     return {
       ...data,

--- a/src/parse-kicad-mod-to-kicad-json.ts
+++ b/src/parse-kicad-mod-to-kicad-json.ts
@@ -1,22 +1,22 @@
+import Debug from "debug"
 import parseSExpression from "s-expression"
+import { formatAttr, getAttr } from "./get-attr"
 import {
-  attributes_def,
-  hole_def,
-  kicad_mod_json_def,
-  pad_def,
   type FpArc,
+  type FpCircle,
   type FpLine,
+  type FpPoly,
   type FpRect,
   type FpText,
-  type FpCircle,
-  type FpPoly,
   type Hole,
   type KicadModJson,
   type Pad,
   type Property,
+  attributes_def,
+  hole_def,
+  kicad_mod_json_def,
+  pad_def,
 } from "./kicad-zod"
-import { formatAttr, getAttr } from "./get-attr"
-import Debug from "debug"
 
 const debug = Debug("kicad-mod-converter")
 
@@ -158,24 +158,6 @@ export const parseKicadModToKicadJson = (fileContent: string): KicadModJson => {
     })
   }
 
-  const fp_rects: FpRect[] = []
-  const fp_rect_rows = kicadSExpr
-    .slice(2)
-    .filter((row: any[]) => row[0] === "fp_rect")
-
-  for (const fp_rect_row of fp_rect_rows) {
-    const start = getAttr(fp_rect_row, "start")
-    const end = getAttr(fp_rect_row, "end")
-    const stroke = getAttr(fp_rect_row, "stroke")
-    const layer = getAttr(fp_rect_row, "layer")
-    const fill = getAttr(fp_rect_row, "fill")
-    const uuid = getAttr(fp_rect_row, "uuid")
-
-    if (!start || !end || !layer) continue
-
-    fp_rects.push({ start, end, stroke, fill, layer, uuid } as any)
-  }
-
   const fp_arcs: FpArc[] = []
   const fp_arcs_rows = kicadSExpr
     .slice(2)
@@ -224,6 +206,34 @@ export const parseKicadModToKicadJson = (fileContent: string): KicadModJson => {
       center,
       end,
       stroke,
+      fill,
+      layer,
+      uuid,
+    })
+  }
+
+  const fp_rects: FpRect[] = []
+  const fp_rects_rows = kicadSExpr
+    .slice(2)
+    .filter((row: any[]) => row[0] === "fp_rect")
+
+  for (const fp_rect_row of fp_rects_rows) {
+    const start = getAttr(fp_rect_row, "start")
+    const end = getAttr(fp_rect_row, "end")
+    const stroke = getAttr(fp_rect_row, "stroke")
+    const width = getAttr(fp_rect_row, "width")
+    const fill = getAttr(fp_rect_row, "fill")
+    const layer = getAttr(fp_rect_row, "layer")
+    const uuid = getAttr(fp_rect_row, "uuid")
+
+    if (!start || !end || !layer) {
+      continue
+    }
+
+    fp_rects.push({
+      start,
+      end,
+      stroke: stroke ?? (typeof width === "number" ? { width } : undefined),
       fill,
       layer,
       uuid,
@@ -323,6 +333,7 @@ export const parseKicadModToKicadJson = (fileContent: string): KicadModJson => {
     fp_texts,
     fp_arcs,
     fp_circles,
+    fp_rects,
     pads,
     holes,
     fp_polys,

--- a/tests/courtyard-rect.test.ts
+++ b/tests/courtyard-rect.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs"
+import { join } from "node:path"
+import { parseKicadModToCircuitJson } from "src"
+
+test("converts fp_rect courtyard to pcb_courtyard_rect", async () => {
+  const fixturePath = join(
+    import.meta.dirname,
+    "data/DIP-10_W10.16mm.kicad_mod",
+  )
+  const fileContent = fs.readFileSync(fixturePath, "utf8")
+
+  const circuitJson = await parseKicadModToCircuitJson(fileContent)
+  const courtyardRects = circuitJson.filter(
+    (element) => element.type === "pcb_courtyard_rect",
+  )
+
+  expect(courtyardRects).toHaveLength(1)
+  const rect = courtyardRects[0] as any
+  expect(rect.type).toBe("pcb_courtyard_rect")
+  expect(rect.pcb_component_id).toBe("pcb_component_0")
+  expect(rect.layer).toBe("top")
+  expect(rect.center.x).toBeCloseTo(5.08, 6)
+  expect(rect.center.y).toBeCloseTo(-5.08, 6)
+  expect(rect.width).toBeCloseTo(12.26, 6)
+  expect(rect.height).toBeCloseTo(13.2, 6)
+})
+
+test("converts courtyard fp_line rectangle to pcb_courtyard_rect", async () => {
+  const fixturePath = join(
+    import.meta.dirname,
+    "data/R_01005_0402Metric.kicad_mod",
+  )
+  const fileContent = fs.readFileSync(fixturePath, "utf8")
+
+  const circuitJson = await parseKicadModToCircuitJson(fileContent)
+  const courtyardRects = circuitJson.filter(
+    (element) => element.type === "pcb_courtyard_rect",
+  )
+
+  expect(courtyardRects).toHaveLength(1)
+  const rect = courtyardRects[0] as any
+  expect(rect.type).toBe("pcb_courtyard_rect")
+  expect(rect.pcb_component_id).toBe("pcb_component_0")
+  expect(rect.layer).toBe("top")
+  expect(rect.center.x).toBeCloseTo(0, 6)
+  expect(rect.center.y).toBeCloseTo(0, 6)
+  expect(rect.width).toBeCloseTo(1.2, 6)
+  expect(rect.height).toBeCloseTo(0.6, 6)
+})


### PR DESCRIPTION
Implements courtyard shape support needed for tscircuit/tscircuit#1081.

What this changes:
- add `fp_rect` schema/type support and parser support in KiCad mod parsing
- convert `fp_rect` on `*.CrtYd` layers into `pcb_courtyard_rect`
- detect closed `fp_line` courtyard loops and emit either `pcb_courtyard_rect` (axis-aligned) or `pcb_courtyard_outline`
- map `F.CrtYd` / `B.CrtYd` layers in layer conversion
- add regression tests for both `fp_rect` and `fp_line` courtyard rectangles

Validation:
- `bun test`
- `bunx biome check src/kicad-zod.ts src/parse-kicad-mod-to-kicad-json.ts src/convert-kicad-json-to-tscircuit-soup.ts tests/courtyard-rect.test.ts`

/claim #1081