### PR TITLE
feat: add kicad_sym support for schematic port arrangement and pin labels

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
+export {
+  parseKicadSymToCircuitJson,
+  enhanceCircuitJsonWithKicadSym,
+} from "./parse-kicad-sym-to-circuit-json"
 export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"

--- a/src/parse-kicad-sym-to-circuit-json.ts
+++ b/src/parse-kicad-sym-to-circuit-json.ts
@@ -1,0 +1,296 @@
+import type { AnyCircuitElement } from "circuit-json"
+import parseSExpression from "s-expression"
+
+type PinSide = "left" | "right" | "top" | "bottom"
+
+interface PinDef {
+  name: string
+  number: string
+  x: number
+  y: number
+  /** KiCad rotation: direction the pin line points OUT FROM component body */
+  rotation: number
+  side: PinSide
+}
+
+/** Safely convert an S-expression symbol / string value to a plain string */
+const textOf = (v: unknown): string => {
+  if (v === undefined || v === null) return ""
+  if (typeof v === "string") return v
+  if (typeof (v as any).valueOf === "function")
+    return String((v as any).valueOf())
+  return String(v)
+}
+
+/** Find all nodes at any depth whose first element matches key */
+const findNodes = (
+  node: unknown,
+  key: string,
+  out: unknown[][] = [],
+): unknown[][] => {
+  if (!Array.isArray(node)) return out
+  if (textOf((node as unknown[])[0]) === key) out.push(node as unknown[])
+  for (const child of node as unknown[]) {
+    if (Array.isArray(child)) findNodes(child, key, out)
+  }
+  return out
+}
+
+/** Return the first child node whose first element matches key */
+const childNode = (parent: unknown[], key: string): unknown[] | undefined =>
+  (parent as unknown[]).find(
+    (child): child is unknown[] =>
+      Array.isArray(child) && textOf((child as unknown[])[0]) === key,
+  ) as unknown[] | undefined
+
+/**
+ * KiCad rotation convention: the rotation value on a (pin ...) node describes
+ * the direction the pin line points *away from* the component body:
+ *
+ *   0   -> points left  -> pin is on the LEFT side
+ *   90  -> points down  -> pin is on the BOTTOM side
+ *   180 -> points right -> pin is on the RIGHT side
+ *   270 -> points up    -> pin is on the TOP side
+ */
+const sideFromRotation = (rotDeg: number): PinSide => {
+  const r = ((rotDeg % 360) + 360) % 360
+  if (r === 180) return "right"
+  if (r === 90) return "bottom"
+  if (r === 270) return "top"
+  return "left" // 0 and anything else
+}
+
+/** Parse a list of (pin ...) S-expression rows into PinDef objects */
+const parsePinRows = (pinRows: unknown[][]): PinDef[] => {
+  const pins: PinDef[] = []
+  for (const row of pinRows) {
+    const atRow = childNode(row as unknown[], "at")
+    const nameRow = childNode(row as unknown[], "name")
+    const numberRow = childNode(row as unknown[], "number")
+    if (!atRow || !nameRow || !numberRow) continue
+
+    const x = Number(textOf((atRow as unknown[])[1]))
+    const y = -Number(textOf((atRow as unknown[])[2])) // flip Y axis
+    const rotation = Number(textOf((atRow as unknown[])[3] ?? 0))
+
+    pins.push({
+      name: textOf((nameRow as unknown[])[1]),
+      number: textOf((numberRow as unknown[])[1]),
+      x,
+      y,
+      rotation,
+      side: sideFromRotation(rotation),
+    })
+  }
+  return pins
+}
+
+/**
+ * Extract symbol name and all pin definitions from a parsed kicad_sym
+ * S-expression.  Handles three common formats:
+ *
+ *   1. Top-level (symbol "Name" ...) - inline symbol, no library wrapper
+ *   2. (kicad_symbol_lib ... (symbol "Name" ...) ...) - library file
+ *   3. Nested sub-symbols: (symbol "Name" (symbol "Name_0_1" (pin ...)))
+ */
+const extractPins = (
+  parsed: unknown[],
+): { symbolName: string; pins: PinDef[] } => {
+  const rootTag = textOf((parsed as unknown[])[0])
+
+  // Case 1: the root node IS a (symbol "Name" ...) already
+  if (rootTag === "symbol") {
+    const symbolName = textOf((parsed as unknown[])[1]) || "KicadSymbol"
+    return { symbolName, pins: parsePinRows(findNodes(parsed, "pin")) }
+  }
+
+  // Case 2: (kicad_symbol_lib ...) wrapper - find child (symbol ...) nodes
+  if (rootTag === "kicad_symbol_lib") {
+    const topSymbols = (parsed as unknown[]).filter(
+      (child): child is unknown[] =>
+        Array.isArray(child) && textOf((child as unknown[])[0]) === "symbol",
+    ) as unknown[][]
+
+    if (topSymbols.length === 0) return { symbolName: "KicadSymbol", pins: [] }
+
+    // Prefer the first symbol whose name does NOT have a sub-symbol suffix (_N_M)
+    const isPrimary = (node: unknown[]) =>
+      !/_\d+_\d+$/.test(textOf((node as unknown[])[1]))
+    const primary = topSymbols.find(isPrimary) ?? topSymbols[0]!
+    const symbolName = textOf((primary as unknown[])[1]) || "KicadSymbol"
+    return { symbolName, pins: parsePinRows(findNodes(primary, "pin")) }
+  }
+
+  // Fallback: search entire tree
+  const anySymbols = findNodes(parsed, "symbol")
+  if (anySymbols.length === 0) return { symbolName: "KicadSymbol", pins: [] }
+  const primary = anySymbols[0]!
+  return {
+    symbolName: textOf((primary as unknown[])[1]) || "KicadSymbol",
+    pins: parsePinRows(findNodes(primary, "pin")),
+  }
+}
+
+/**
+ * Parse a KiCad .kicad_sym file and return a circuit-JSON array suitable for
+ * rendering the schematic view, including:
+ *
+ * - source_component   (one, named after the symbol)
+ * - schematic_component (with schPortArrangement and pinLabels)
+ * - source_port         (one per pin)
+ * - schematic_port      (one per pin, positioned at the pin's x/y)
+ *
+ * @param kicadSym - raw text content of a .kicad_sym file
+ */
+export const parseKicadSymToCircuitJson = async (
+  kicadSym: string,
+): Promise<AnyCircuitElement[]> => {
+  const parsed: unknown[] = parseSExpression(kicadSym)
+  const { symbolName, pins } = extractPins(parsed)
+
+  const source_component_id = "source_component_0"
+  const schematic_component_id = "schematic_component_0"
+
+  // Bounding box of pin positions for sizing the schematic component
+  const xs = pins.map((p) => p.x)
+  const ys = pins.map((p) => p.y)
+  const minX = xs.length ? Math.min(...xs) : -5
+  const maxX = xs.length ? Math.max(...xs) : 5
+  const minY = ys.length ? Math.min(...ys) : -5
+  const maxY = ys.length ? Math.max(...ys) : 5
+
+  const schPortArrangement = {
+    leftSide: pins.filter((p) => p.side === "left").map((p) => p.number),
+    rightSide: pins.filter((p) => p.side === "right").map((p) => p.number),
+    topSide: pins.filter((p) => p.side === "top").map((p) => p.number),
+    bottomSide: pins.filter((p) => p.side === "bottom").map((p) => p.number),
+  }
+
+  // Only include sides that have at least one pin to keep the object clean
+  const compactArrangement = Object.fromEntries(
+    Object.entries(schPortArrangement).filter(([, v]) => v.length > 0),
+  ) as typeof schPortArrangement
+
+  const pinLabels: Record<string, string> = {}
+  for (const pin of pins) {
+    pinLabels[pin.number] = pin.name || pin.number
+  }
+
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id,
+      name: symbolName,
+      supplier_part_numbers: {},
+    } as any,
+    {
+      type: "schematic_component",
+      schematic_component_id,
+      source_component_id,
+      center: { x: (minX + maxX) / 2, y: (minY + maxY) / 2 },
+      rotation: 0,
+      size: {
+        width: Math.max(10, maxX - minX + 10),
+        height: Math.max(10, maxY - minY + 10),
+      },
+      schPortArrangement: compactArrangement,
+      pinLabels,
+    } as any,
+  ]
+
+  for (let i = 0; i < pins.length; i++) {
+    const pin = pins[i]!
+    const source_port_id = `source_port_${i}`
+    const schematic_port_id = `schematic_port_${i}`
+    const numericPinNumber = Number(pin.number)
+
+    circuitJson.push({
+      type: "source_port",
+      source_port_id,
+      source_component_id,
+      name: pin.number,
+      port_hints: [pin.number, pin.name].filter(Boolean),
+      pin_number: Number.isFinite(numericPinNumber)
+        ? numericPinNumber
+        : undefined,
+      pin_label: pin.name || pin.number,
+    } as any)
+
+    circuitJson.push({
+      type: "schematic_port",
+      schematic_port_id,
+      schematic_component_id,
+      source_port_id,
+      center: { x: pin.x, y: pin.y },
+      facingDirection: pin.side,
+    } as any)
+  }
+
+  return circuitJson
+}
+
+/**
+ * Enhance an existing circuit-JSON array (typically produced from a .kicad_mod
+ * file) by overlaying schematic data from a .kicad_sym symbol file.
+ *
+ * The sym data provides:
+ *  - schPortArrangement - which pins sit on left/right/top/bottom
+ *  - pinLabels          - human-readable pin names keyed by pin number
+ *
+ * This is additive and non-destructive: PCB-specific elements are unchanged.
+ *
+ * @param circuitJson - existing circuit-JSON array from kicad_mod conversion
+ * @param kicadSym    - raw text content of the accompanying .kicad_sym file
+ */
+export const enhanceCircuitJsonWithKicadSym = async (
+  circuitJson: AnyCircuitElement[],
+  kicadSym: string,
+): Promise<AnyCircuitElement[]> => {
+  const parsed: unknown[] = parseSExpression(kicadSym)
+  const { pins } = extractPins(parsed)
+
+  if (pins.length === 0) return circuitJson
+
+  const schPortArrangement = {
+    leftSide: pins.filter((p) => p.side === "left").map((p) => p.number),
+    rightSide: pins.filter((p) => p.side === "right").map((p) => p.number),
+    topSide: pins.filter((p) => p.side === "top").map((p) => p.number),
+    bottomSide: pins.filter((p) => p.side === "bottom").map((p) => p.number),
+  }
+
+  const compactArrangement = Object.fromEntries(
+    Object.entries(schPortArrangement).filter(([, v]) => v.length > 0),
+  ) as typeof schPortArrangement
+
+  const pinLabels: Record<string, string> = {}
+  for (const pin of pins) {
+    pinLabels[pin.number] = pin.name || pin.number
+  }
+
+  // Map from pin number string -> pin name (for updating source_port labels)
+  const pinNameByNumber = new Map(pins.map((p) => [p.number, p.name]))
+
+  return circuitJson.map((element) => {
+    if ((element as any).type === "schematic_component") {
+      return {
+        ...element,
+        schPortArrangement: compactArrangement,
+        pinLabels,
+      }
+    }
+    if ((element as any).type === "source_port") {
+      const el = element as any
+      const pinName =
+        pinNameByNumber.get(el.name) ??
+        pinNameByNumber.get(String(el.pin_number))
+      if (pinName) {
+        return {
+          ...el,
+          pin_label: pinName,
+          port_hints: [...new Set([...(el.port_hints ?? []), pinName])],
+        }
+      }
+    }
+    return element
+  }) as AnyCircuitElement[]
+}

--- a/src/site/App.tsx
+++ b/src/site/App.tsx
@@ -2,6 +2,10 @@ import { useCallback, useState, useRef } from "react"
 import { useStore } from "./use-store"
 import { Download, FileSearch } from "lucide-react"
 import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import {
+  parseKicadSymToCircuitJson,
+  enhanceCircuitJsonWithKicadSym,
+} from "src/parse-kicad-sym-to-circuit-json"
 import { CircuitJsonPreview } from "@tscircuit/runframe"
 import { convertCircuitJsonToTscircuit } from "circuit-json-to-tscircuit"
 import { createSnippetUrl } from "@tscircuit/create-snippet-url"
@@ -19,17 +23,31 @@ export const App = () => {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const handleProcessAndViewFiles = useCallback(async () => {
-    if (!filesAdded.kicad_mod) {
-      setError("No KiCad Mod file added")
+    if (!filesAdded.kicad_mod && !filesAdded.kicad_sym) {
+      setError("No KiCad file added (.kicad_mod or .kicad_sym)")
       return
     }
     setError(null)
     let circuitJson: any
     try {
-      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+      if (filesAdded.kicad_mod) {
+        // Parse PCB footprint
+        circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+        // If a symbol file was also provided, enhance the schematic view with
+        // proper pin arrangement and pin labels from the symbol.
+        if (filesAdded.kicad_sym) {
+          circuitJson = await enhanceCircuitJsonWithKicadSym(
+            circuitJson,
+            filesAdded.kicad_sym,
+          )
+        }
+      } else if (filesAdded.kicad_sym) {
+        // Symbol-only mode: derive a schematic-only view from the sym file
+        circuitJson = await parseKicadSymToCircuitJson(filesAdded.kicad_sym)
+      }
       updateCircuitJson(circuitJson as any)
     } catch (err: any) {
-      setError(`Error parsing KiCad Mod file: ${err.toString()}`)
+      setError(`Error parsing KiCad file: ${err.toString()}`)
       return
     }
 
@@ -145,12 +163,33 @@ export const App = () => {
             <div className="flex items-center gap-2 bg-gray-800/50 p-3 rounded-md">
               <span
                 className={
-                  filesAdded.kicad_mod ? "text-green-500" : "text-red-500"
+                  filesAdded.kicad_mod ? "text-green-500" : "text-gray-500"
                 }
               >
-                {filesAdded.kicad_mod ? "✅" : "❌"}
+                {filesAdded.kicad_mod ? "✅" : "⬜"}
               </span>
-              <span className="text-gray-300">KiCad Mod File</span>
+              <span className="text-gray-300">
+                KiCad Mod File{" "}
+                <span className="text-gray-500 text-xs">
+                  (optional — PCB footprint)
+                </span>
+              </span>
+            </div>
+            <div className="flex items-center gap-2 bg-gray-800/50 p-3 rounded-md">
+              <span
+                className={
+                  filesAdded.kicad_sym ? "text-green-500" : "text-gray-500"
+                }
+              >
+                {filesAdded.kicad_sym ? "✅" : "⬜"}
+              </span>
+              <span className="text-gray-300">
+                KiCad Sym File{" "}
+                <span className="text-gray-500 text-xs">
+                  (optional — schematic symbol, adds pin labels &amp; port
+                  arrangement)
+                </span>
+              </span>
             </div>
           </div>
           <div className="flex justify-center items-center gap-2">

--- a/tests/kicad-sym-parse.test.ts
+++ b/tests/kicad-sym-parse.test.ts
@@ -1,0 +1,210 @@
+import { expect, test } from "bun:test"
+import {
+  parseKicadSymToCircuitJson,
+  enhanceCircuitJsonWithKicadSym,
+} from "src/parse-kicad-sym-to-circuit-json"
+import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import fs from "node:fs"
+import path from "node:path"
+
+// --------------------------------------------------------------------------
+// Minimal inline symbol (no library wrapper)
+// --------------------------------------------------------------------------
+const SIMPLE_SYM = `(symbol "TestChip"
+  (pin_names (offset 0))
+  (symbol "TestChip_0_1"
+    (pin passive line (at 0 0 0) (length 2.54)
+      (name "IN" (effects (font (size 1.27 1.27))))
+      (number "1" (effects (font (size 1.27 1.27))))
+    )
+    (pin passive line (at 10 0 180) (length 2.54)
+      (name "OUT" (effects (font (size 1.27 1.27))))
+      (number "2" (effects (font (size 1.27 1.27))))
+    )
+    (pin passive line (at 5 -5 90) (length 2.54)
+      (name "GND" (effects (font (size 1.27 1.27))))
+      (number "3" (effects (font (size 1.27 1.27))))
+    )
+    (pin passive line (at 5 5 270) (length 2.54)
+      (name "VCC" (effects (font (size 1.27 1.27))))
+      (number "4" (effects (font (size 1.27 1.27))))
+    )
+  )
+)`
+
+test("parseKicadSymToCircuitJson: basic four-sided pin placement", async () => {
+  const cj = await parseKicadSymToCircuitJson(SIMPLE_SYM)
+
+  const sc = cj.find((x: any) => x.type === "schematic_component") as any
+  expect(sc).toBeTruthy()
+
+  // Pin 1 at rotation=0 → left side
+  expect(sc.schPortArrangement.leftSide).toContain("1")
+  // Pin 2 at rotation=180 → right side
+  expect(sc.schPortArrangement.rightSide).toContain("2")
+  // Pin 3 at rotation=90 → bottom side
+  expect(sc.schPortArrangement.bottomSide).toContain("3")
+  // Pin 4 at rotation=270 → top side
+  expect(sc.schPortArrangement.topSide).toContain("4")
+
+  // pinLabels
+  expect(sc.pinLabels["1"]).toBe("IN")
+  expect(sc.pinLabels["2"]).toBe("OUT")
+  expect(sc.pinLabels["3"]).toBe("GND")
+  expect(sc.pinLabels["4"]).toBe("VCC")
+
+  // Source / schematic ports
+  const sourcePorts = cj.filter((x: any) => x.type === "source_port")
+  const schPorts = cj.filter((x: any) => x.type === "schematic_port")
+  expect(sourcePorts).toHaveLength(4)
+  expect(schPorts).toHaveLength(4)
+
+  // Source component name
+  const comp = cj.find((x: any) => x.type === "source_component") as any
+  expect(comp?.name).toBe("TestChip")
+})
+
+test("parseKicadSymToCircuitJson: numeric pin_number assigned for integer pins", async () => {
+  const cj = await parseKicadSymToCircuitJson(SIMPLE_SYM)
+  const sp1 = (cj as any[]).find(
+    (x: any) => x.type === "source_port" && x.name === "1",
+  )
+  expect(sp1?.pin_number).toBe(1)
+})
+
+test("parseKicadSymToCircuitJson: non-numeric pin number has no pin_number", async () => {
+  const sym = `(symbol "IC"
+    (symbol "IC_0_1"
+      (pin input line (at 0 0 0) (length 2.54)
+        (name "A0" (effects (font (size 1.27 1.27))))
+        (number "A0" (effects (font (size 1.27 1.27))))
+      )
+    )
+  )`
+  const cj = await parseKicadSymToCircuitJson(sym)
+  const sp = (cj as any[]).find(
+    (x: any) => x.type === "source_port" && x.name === "A0",
+  )
+  expect(sp?.pin_number).toBeUndefined()
+  expect(sp?.pin_label).toBe("A0")
+})
+
+// --------------------------------------------------------------------------
+// kicad_symbol_lib wrapper (as shipped in KiCad library files)
+// --------------------------------------------------------------------------
+const LIB_SYM = `(kicad_symbol_lib
+  (version 20211014)
+  (generator kicad_symbol_editor)
+  (symbol "Resistor"
+    (pin_names (offset 0) hide)
+    (symbol "Resistor_0_1"
+      (pin passive line (at 0 0 0) (length 2.54)
+        (name "~" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27))))
+      )
+      (pin passive line (at 10 0 180) (length 2.54)
+        (name "~" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27))))
+      )
+    )
+  )
+)`
+
+test("parseKicadSymToCircuitJson: parses kicad_symbol_lib wrapper correctly", async () => {
+  const cj = await parseKicadSymToCircuitJson(LIB_SYM)
+
+  const comp = cj.find((x: any) => x.type === "source_component") as any
+  expect(comp?.name).toBe("Resistor")
+
+  const sc = cj.find((x: any) => x.type === "schematic_component") as any
+  expect(sc?.schPortArrangement?.leftSide).toContain("1")
+  expect(sc?.schPortArrangement?.rightSide).toContain("2")
+})
+
+test("parseKicadSymToCircuitJson: empty sides are omitted from schPortArrangement", async () => {
+  // All pins on left/right — no top or bottom
+  const cj = await parseKicadSymToCircuitJson(LIB_SYM)
+  const sc = cj.find((x: any) => x.type === "schematic_component") as any
+  expect(sc?.schPortArrangement?.topSide).toBeUndefined()
+  expect(sc?.schPortArrangement?.bottomSide).toBeUndefined()
+})
+
+// --------------------------------------------------------------------------
+// enhanceCircuitJsonWithKicadSym: overlay sym data onto kicad_mod circuit JSON
+// --------------------------------------------------------------------------
+test("enhanceCircuitJsonWithKicadSym: adds schPortArrangement and pinLabels to schematic_component", async () => {
+  const modContent = fs.readFileSync(
+    path.join(__dirname, "data/Crystal_SMD_HC49-US.kicad_mod"),
+    "utf8",
+  )
+  const baseCj = await parseKicadModToCircuitJson(modContent)
+
+  // Verify baseline has no schPortArrangement
+  const baseSc = baseCj.find(
+    (x: any) => x.type === "schematic_component",
+  ) as any
+  expect(baseSc?.schPortArrangement).toBeUndefined()
+
+  const mockSym = `(symbol "Crystal"
+    (symbol "Crystal_0_1"
+      (pin passive line (at 0 0 0) (length 2.54)
+        (name "P1" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27))))
+      )
+      (pin passive line (at 10 0 180) (length 2.54)
+        (name "P2" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27))))
+      )
+    )
+  )`
+
+  const enhanced = await enhanceCircuitJsonWithKicadSym(baseCj, mockSym)
+
+  const sc = enhanced.find((x: any) => x.type === "schematic_component") as any
+  expect(sc?.schPortArrangement?.leftSide).toContain("1")
+  expect(sc?.schPortArrangement?.rightSide).toContain("2")
+  expect(sc?.pinLabels?.["1"]).toBe("P1")
+  expect(sc?.pinLabels?.["2"]).toBe("P2")
+
+  // PCB elements should be unchanged
+  const pcbPads = enhanced.filter((x: any) => x.type === "pcb_smtpad")
+  const origPads = baseCj.filter((x: any) => x.type === "pcb_smtpad")
+  expect(pcbPads).toHaveLength(origPads.length)
+})
+
+test("enhanceCircuitJsonWithKicadSym: updates source_port pin_label when pin name available", async () => {
+  const modContent = fs.readFileSync(
+    path.join(__dirname, "data/Crystal_SMD_HC49-US.kicad_mod"),
+    "utf8",
+  )
+  const baseCj = await parseKicadModToCircuitJson(modContent)
+
+  const mockSym = `(symbol "XTAL"
+    (symbol "XTAL_0_1"
+      (pin passive line (at 0 0 0) (length 2.54)
+        (name "XTAL_IN" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27))))
+      )
+    )
+  )`
+
+  const enhanced = await enhanceCircuitJsonWithKicadSym(baseCj, mockSym)
+
+  const sp = (enhanced as any[]).find(
+    (x: any) => x.type === "source_port" && x.name === "1",
+  )
+  expect(sp?.pin_label).toBe("XTAL_IN")
+  expect(sp?.port_hints).toContain("XTAL_IN")
+})
+
+test("enhanceCircuitJsonWithKicadSym: no-op when sym has no pins", async () => {
+  const modContent = fs.readFileSync(
+    path.join(__dirname, "data/Crystal_SMD_HC49-US.kicad_mod"),
+    "utf8",
+  )
+  const baseCj = await parseKicadModToCircuitJson(modContent)
+
+  const emptySym = `(symbol "Empty" (symbol "Empty_0_1"))`
+  const result = await enhanceCircuitJsonWithKicadSym(baseCj, emptySym)
+  expect(result).toBe(baseCj) // same reference — unchanged
+})


### PR DESCRIPTION
/claim #114

## Summary

Adds `.kicad_sym` support to the converter so the schematic view shows correct pin arrangement and human-readable pin labels. Supports three workflows:

1. **`.kicad_mod` only** — existing behaviour unchanged
2. **`.kicad_sym` only** — new: derive a schematic-only view from the symbol file
3. **`.kicad_mod` + `.kicad_sym`** — new: PCB footprint view enhanced with schematic pin data from the symbol

## What changed

### `src/parse-kicad-sym-to-circuit-json.ts` (new file)

**`parseKicadSymToCircuitJson(kicadSym)`**
- Parses a `.kicad_sym` file (with or without `kicad_symbol_lib` wrapper)
- Handles nested sub-symbols (e.g. `Name_0_1`)
- Maps KiCad pin rotation values to `left` / `right` / `top` / `bottom` sides
- Returns `source_component`, `schematic_component` (with `schPortArrangement` + `pinLabels`), `source_port`, and `schematic_port` elements

**`enhanceCircuitJsonWithKicadSym(circuitJson, kicadSym)`**
- Overlays sym pin data onto an existing kicad_mod-derived circuit-JSON array
- Adds `schPortArrangement` and `pinLabels` to `schematic_component`
- Updates `source_port` `pin_label` and `port_hints` with sym pin names
- PCB elements (`pcb_smtpad`, `pcb_trace`, etc.) are completely untouched

### `src/index.ts`
- Exports both new functions

### `src/site/App.tsx`
- Updated `handleProcessAndViewFiles` to handle all three workflows
- UI shows both file slots as optional with descriptive labels

## KiCad rotation → side mapping

| Rotation | Pin points toward | Side |
|----------|------------------|------|
| 0        | left             | left |
| 90       | down             | bottom |
| 180      | right            | right |
| 270      | up               | top |

## Tests (`tests/kicad-sym-parse.test.ts`)

8 new tests covering:
- Four-sided pin placement from rotation values
- Numeric vs non-numeric `pin_number` handling  
- `kicad_symbol_lib` wrapper parsing
- Empty sides omitted from `schPortArrangement`
- Enhance overlay on kicad_mod circuit-JSON
- `source_port` `pin_label` and `port_hints` update after overlay
- No-op when sym has no pins

**All 30 tests pass, format clean (biome).**

Closes #114