### PR TITLE
feat: add .kicad_sym parser → schPortArrangement + pinLabels

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
 export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"
+export {
+  parseKicadSymToTscircuit,
+  type SchPortArrangement,
+  type KicadSymTscircuitOutput,
+} from "./parse-kicad-sym-to-tscircuit"

--- a/src/parse-kicad-sym-to-tscircuit.ts
+++ b/src/parse-kicad-sym-to-tscircuit.ts
@@ -1,0 +1,173 @@
+import parseSExpression from "s-expression"
+
+export type SchPortArrangement = {
+  leftSide?: { pins: number[] }
+  rightSide?: { pins: number[] }
+  topSide?: { pins: number[] }
+  bottomSide?: { pins: number[] }
+}
+
+export type KicadSymTscircuitOutput = {
+  /** Maps pin number (string) to pin label/name */
+  pinLabels: Record<string, string>
+  /** Arrangement of pins around the schematic symbol */
+  schPortArrangement: SchPortArrangement
+}
+
+type ParsedPin = {
+  number: string
+  name: string
+  /** KiCad pin angle: 0=right(→left side), 180=left(→right), 90=up(→bottom), 270=down(→top) */
+  angle: number
+}
+
+/**
+ * Recursively traverses an s-expression tree and collects all `(pin ...)` entries.
+ */
+function collectPins(node: any[]): ParsedPin[] {
+  const pins: ParsedPin[] = []
+
+  if (!Array.isArray(node)) return pins
+
+  for (const child of node) {
+    if (!Array.isArray(child)) continue
+
+    const tag = String(child[0])
+
+    if (tag === "pin") {
+      // (pin <elec_type> <graphic_type> (at X Y ANGLE) (length L)
+      //   (name "..." ...) (number "..." ...) )
+      const atEntry = child.find(
+        (c: any) => Array.isArray(c) && String(c[0]) === "at",
+      )
+      const nameEntry = child.find(
+        (c: any) => Array.isArray(c) && String(c[0]) === "name",
+      )
+      const numberEntry = child.find(
+        (c: any) => Array.isArray(c) && String(c[0]) === "number",
+      )
+
+      if (!atEntry || !nameEntry || !numberEntry) continue
+
+      const angle = Number(atEntry[3]) ?? 0
+      const name = String(nameEntry[1])
+      const number = String(numberEntry[1])
+
+      // Skip no-connect pins (name "~" or number "~")
+      if (name === "~" && number === "~") continue
+
+      pins.push({ number, name, angle })
+    } else {
+      // Recurse into sub-symbols and other nodes
+      pins.push(...collectPins(child))
+    }
+  }
+
+  return pins
+}
+
+/**
+ * Maps a KiCad pin angle to the schematic symbol side.
+ *
+ * In KiCad, the pin angle is the direction the stub *points*:
+ *   0°  → stub points right  → pin is on the LEFT  side of the body
+ *  90°  → stub points up     → pin is on the BOTTOM side (Y-down convention)
+ * 180°  → stub points left   → pin is on the RIGHT side
+ * 270°  → stub points down   → pin is on the TOP   side
+ */
+function angleToSide(angle: number): "leftSide" | "rightSide" | "topSide" | "bottomSide" {
+  const normalized = ((angle % 360) + 360) % 360
+  if (normalized === 0) return "leftSide"
+  if (normalized === 90) return "bottomSide"
+  if (normalized === 180) return "rightSide"
+  if (normalized === 270) return "topSide"
+  // Non-standard angle — fall back by quadrant
+  if (normalized < 90) return "leftSide"
+  if (normalized < 180) return "bottomSide"
+  if (normalized < 270) return "rightSide"
+  return "topSide"
+}
+
+/**
+ * Parse a `.kicad_sym` file and return `pinLabels` + `schPortArrangement`
+ * suitable for use with the tscircuit `<chip>` component.
+ *
+ * @param fileContent - Raw text content of the `.kicad_sym` file
+ * @param symbolName  - Optional: pick a specific symbol by name when the
+ *                      library contains multiple symbols. Defaults to the
+ *                      first symbol found.
+ */
+export function parseKicadSymToTscircuit(
+  fileContent: string,
+  symbolName?: string,
+): KicadSymTscircuitOutput {
+  const sExpr = parseSExpression(fileContent)
+
+  // Locate the requested (or first) top-level symbol entry
+  const symbols = sExpr
+    .slice(1)
+    .filter((node: any) => Array.isArray(node) && String(node[0]) === "symbol")
+
+  if (symbols.length === 0) {
+    throw new Error("No symbol definitions found in kicad_sym file")
+  }
+
+  let symbolNode: any[]
+  if (symbolName) {
+    symbolNode = symbols.find((s: any) => String(s[1]) === symbolName)
+    if (!symbolNode) {
+      throw new Error(
+        `Symbol "${symbolName}" not found. Available: ${symbols.map((s: any) => String(s[1])).join(", ")}`,
+      )
+    }
+  } else {
+    symbolNode = symbols[0]
+  }
+
+  // Collect all pins, deduplicating by pin number (multi-unit symbols repeat
+  // the same physical pin across units)
+  const allPins = collectPins(symbolNode)
+  const seenNumbers = new Set<string>()
+  const uniquePins: ParsedPin[] = []
+  for (const pin of allPins) {
+    if (!seenNumbers.has(pin.number)) {
+      seenNumbers.add(pin.number)
+      uniquePins.push(pin)
+    }
+  }
+
+  // Build pinLabels: { "1": "GND", "2": "TRIG", ... }
+  const pinLabels: Record<string, string> = {}
+  for (const pin of uniquePins) {
+    pinLabels[pin.number] = pin.name
+  }
+
+  // Group pin numbers by schematic side
+  const sideMap: Record<string, number[]> = {
+    leftSide: [],
+    rightSide: [],
+    topSide: [],
+    bottomSide: [],
+  }
+  for (const pin of uniquePins) {
+    const side = angleToSide(pin.angle)
+    sideMap[side].push(Number(pin.number))
+  }
+
+  // Sort pins on each side by pin number for deterministic output
+  for (const side of Object.keys(sideMap)) {
+    sideMap[side].sort((a, b) => a - b)
+  }
+
+  const schPortArrangement: SchPortArrangement = {}
+  if (sideMap.leftSide.length > 0)
+    schPortArrangement.leftSide = { pins: sideMap.leftSide }
+  if (sideMap.rightSide.length > 0)
+    schPortArrangement.rightSide = { pins: sideMap.rightSide }
+  if (sideMap.topSide.length > 0)
+    schPortArrangement.topSide = { pins: sideMap.topSide }
+  if (sideMap.bottomSide.length > 0)
+    schPortArrangement.bottomSide = { pins: sideMap.bottomSide }
+
+  return { pinLabels, schPortArrangement }
+}

--- a/src/parse-kicad-sym-to-tscircuit.ts
+++ b/src/parse-kicad-sym-to-tscircuit.ts
@@ -75,7 +75,9 @@ function collectPins(node: any[]): ParsedPin[] {
  * 180°  → stub points left   → pin is on the RIGHT side
  * 270°  → stub points down   → pin is on the TOP   side
  */
-function angleToSide(angle: number): "leftSide" | "rightSide" | "topSide" | "bottomSide" {
+function angleToSide(
+  angle: number,
+): "leftSide" | "rightSide" | "topSide" | "bottomSide" {
   const normalized = ((angle % 360) + 360) % 360
   if (normalized === 0) return "leftSide"
   if (normalized === 90) return "bottomSide"

--- a/src/site/App.tsx
+++ b/src/site/App.tsx
@@ -2,12 +2,14 @@ import { useCallback, useState, useRef } from "react"
 import { useStore } from "./use-store"
 import { Download, FileSearch } from "lucide-react"
 import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import { parseKicadSymToTscircuit } from "src/parse-kicad-sym-to-tscircuit"
 import { CircuitJsonPreview } from "@tscircuit/runframe"
 import { convertCircuitJsonToTscircuit } from "circuit-json-to-tscircuit"
 import { createSnippetUrl } from "@tscircuit/create-snippet-url"
 
 export const App = () => {
   const [error, setError] = useState<string | null>(null)
+  const [symOutput, setSymOutput] = useState<string | null>(null)
   const filesAdded = useStore((s) => s.filesAdded)
   const addFile = useStore((s) => s.addFile)
   const reset = useStore((s) => s.reset)
@@ -19,14 +21,47 @@ export const App = () => {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const handleProcessAndViewFiles = useCallback(async () => {
+    setError(null)
+    setSymOutput(null)
+
+    // kicad_sym only: generate schPortArrangement + pinLabels
+    if (filesAdded.kicad_sym && !filesAdded.kicad_mod) {
+      try {
+        const result = parseKicadSymToTscircuit(filesAdded.kicad_sym)
+        setSymOutput(JSON.stringify(result, null, 2))
+      } catch (err: any) {
+        setError(`Error parsing KiCad Sym file: ${err.toString()}`)
+      }
+      return
+    }
+
     if (!filesAdded.kicad_mod) {
       setError("No KiCad Mod file added")
       return
     }
-    setError(null)
+
     let circuitJson: any
     try {
       circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+
+      // If a kicad_sym was also provided, enhance the circuit JSON with
+      // schPortArrangement and pinLabels from the symbol file.
+      if (filesAdded.kicad_sym) {
+        try {
+          const symResult = parseKicadSymToTscircuit(filesAdded.kicad_sym)
+          // Attach sym data to the schematic_component element if present
+          const schComp = circuitJson.find(
+            (el: any) => el.type === "schematic_component",
+          )
+          if (schComp) {
+            schComp.port_arrangement = symResult.schPortArrangement
+            schComp.pin_labels = symResult.pinLabels
+          }
+        } catch {
+          // Non-fatal: sym enhancement failed, proceed with mod-only result
+        }
+      }
+
       updateCircuitJson(circuitJson as any)
     } catch (err: any) {
       setError(`Error parsing KiCad Mod file: ${err.toString()}`)
@@ -145,12 +180,25 @@ export const App = () => {
             <div className="flex items-center gap-2 bg-gray-800/50 p-3 rounded-md">
               <span
                 className={
-                  filesAdded.kicad_mod ? "text-green-500" : "text-red-500"
+                  filesAdded.kicad_mod ? "text-green-500" : "text-gray-500"
                 }
               >
-                {filesAdded.kicad_mod ? "✅" : "❌"}
+                {filesAdded.kicad_mod ? "✅" : "⬜"}
               </span>
-              <span className="text-gray-300">KiCad Mod File</span>
+              <span className="text-gray-300">KiCad Mod File (.kicad_mod)</span>
+            </div>
+            <div className="flex items-center gap-2 bg-gray-800/50 p-3 rounded-md">
+              <span
+                className={
+                  filesAdded.kicad_sym ? "text-green-500" : "text-gray-500"
+                }
+              >
+                {filesAdded.kicad_sym ? "✅" : "⬜"}
+              </span>
+              <span className="text-gray-300">
+                KiCad Sym File (.kicad_sym) — optional, adds schematic pin
+                arrangement
+              </span>
             </div>
           </div>
           <div className="flex justify-center items-center gap-2">
@@ -242,6 +290,16 @@ export const App = () => {
               </button>
             )}
           </div>
+          {symOutput && !circuitJson && (
+            <div className="w-full bg-gray-800/50 p-4 rounded-md text-left">
+              <h2 className="text-lg font-semibold text-green-400 mb-2">
+                KiCad Sym Output (pinLabels + schPortArrangement)
+              </h2>
+              <pre className="text-xs text-gray-300 whitespace-pre-wrap overflow-x-auto">
+                {symOutput}
+              </pre>
+            </div>
+          )}
           {circuitJson && (
             <div className="w-full bg-gray-800/50 px-2 rounded-md">
               <CircuitJsonPreview

--- a/tests/data/NE555.kicad_sym
+++ b/tests/data/NE555.kicad_sym
@@ -1,0 +1,184 @@
+(kicad_symbol_lib
+  (version 20211014)
+  (generator kicad_symbol_editor)
+  (symbol "NE555"
+    (pin_names
+      (offset 1.016)
+    )
+    (in_bom yes)
+    (on_board yes)
+    (property "Reference" "U"
+      (at 0 11.43 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "NE555"
+      (at 0 -11.43 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (symbol "NE555_1_1"
+      (rectangle
+        (start -10.16 10.16)
+        (end 10.16 -10.16)
+        (stroke
+          (width 0)
+          (type default)
+        )
+        (fill
+          (type background)
+        )
+      )
+      (pin power_in line
+        (at -15.24 7.62 0)
+        (length 5.08)
+        (name "GND"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+        (number "1"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+      )
+      (pin input line
+        (at -15.24 2.54 0)
+        (length 5.08)
+        (name "TRIG"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+        (number "2"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+      )
+      (pin output line
+        (at 15.24 0 180)
+        (length 5.08)
+        (name "OUT"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+        (number "3"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+      )
+      (pin input line
+        (at -15.24 -2.54 0)
+        (length 5.08)
+        (name "RESET"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+        (number "4"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+      )
+      (pin input line
+        (at 15.24 -5.08 180)
+        (length 5.08)
+        (name "CV"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+        (number "5"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+      )
+      (pin input line
+        (at -15.24 -7.62 0)
+        (length 5.08)
+        (name "THR"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+        (number "6"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+      )
+      (pin open_collector line
+        (at 15.24 5.08 180)
+        (length 5.08)
+        (name "DIS"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+        (number "7"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+      )
+      (pin power_in line
+        (at 0 15.24 270)
+        (length 5.08)
+        (name "VCC"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+        (number "8"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/kicad-sym-parser.test.ts
+++ b/tests/kicad-sym-parser.test.ts
@@ -1,0 +1,85 @@
+import { test, expect } from "bun:test"
+import { parseKicadSymToTscircuit } from "src"
+import { readFileSync } from "fs"
+import { join } from "path"
+
+const NE555_PATH = join(import.meta.dirname, "data/NE555.kicad_sym")
+const NE555_CONTENT = readFileSync(NE555_PATH, "utf8")
+
+test("NE555: pinLabels maps all 8 pins correctly", () => {
+  const { pinLabels } = parseKicadSymToTscircuit(NE555_CONTENT)
+
+  expect(pinLabels["1"]).toBe("GND")
+  expect(pinLabels["2"]).toBe("TRIG")
+  expect(pinLabels["3"]).toBe("OUT")
+  expect(pinLabels["4"]).toBe("RESET")
+  expect(pinLabels["5"]).toBe("CV")
+  expect(pinLabels["6"]).toBe("THR")
+  expect(pinLabels["7"]).toBe("DIS")
+  expect(pinLabels["8"]).toBe("VCC")
+  expect(Object.keys(pinLabels)).toHaveLength(8)
+})
+
+test("NE555: schPortArrangement assigns pins to correct sides", () => {
+  const { schPortArrangement } = parseKicadSymToTscircuit(NE555_CONTENT)
+
+  // angle 0 → left side: pins 1 (GND), 2 (TRIG), 4 (RESET), 6 (THR)
+  expect(schPortArrangement.leftSide?.pins).toEqual([1, 2, 4, 6])
+
+  // angle 180 → right side: pins 3 (OUT), 5 (CV), 7 (DIS)
+  expect(schPortArrangement.rightSide?.pins).toEqual([3, 5, 7])
+
+  // angle 270 → top side: pin 8 (VCC)
+  expect(schPortArrangement.topSide?.pins).toEqual([8])
+
+  // no bottom side pins in NE555
+  expect(schPortArrangement.bottomSide).toBeUndefined()
+})
+
+test("throws when symbolName is not found in library", () => {
+  expect(() =>
+    parseKicadSymToTscircuit(NE555_CONTENT, "NONEXISTENT_IC"),
+  ).toThrow(/NONEXISTENT_IC/)
+})
+
+test("explicit symbolName selects the correct symbol", () => {
+  const { pinLabels } = parseKicadSymToTscircuit(NE555_CONTENT, "NE555")
+  expect(pinLabels["1"]).toBe("GND")
+  expect(Object.keys(pinLabels)).toHaveLength(8)
+})
+
+test("inline two-pin symbol: each pin assigned to opposite sides", () => {
+  const twoPin = `
+(kicad_symbol_lib
+  (version 20211014)
+  (generator kicad_symbol_editor)
+  (symbol "R"
+    (in_bom yes)
+    (on_board yes)
+    (symbol "R_1_1"
+      (pin passive line
+        (at -5.08 0 0)
+        (length 2.54)
+        (name "~" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27))))
+      )
+      (pin passive line
+        (at 5.08 0 180)
+        (length 2.54)
+        (name "~" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27))))
+      )
+    )
+  )
+)
+`
+  const { pinLabels, schPortArrangement } = parseKicadSymToTscircuit(twoPin)
+
+  // Resistor: pin 1 on left (angle 0), pin 2 on right (angle 180)
+  expect(schPortArrangement.leftSide?.pins).toEqual([1])
+  expect(schPortArrangement.rightSide?.pins).toEqual([2])
+
+  // Names are "~" (unnamed pins in KiCad)
+  expect(pinLabels["1"]).toBe("~")
+  expect(pinLabels["2"]).toBe("~")
+})


### PR DESCRIPTION
## Summary

Implements `parseKicadSymToTscircuit()` — a parser for `.kicad_sym` (KiCad schematic symbol) files that outputs `pinLabels` and `schPortArrangement` props ready for use with the tscircuit `<chip>` component.

### New API

```ts
import { parseKicadSymToTscircuit } from 'kicad-component-converter'

const { pinLabels, schPortArrangement } = parseKicadSymToTscircuit(
  fs.readFileSync('NE555.kicad_sym', 'utf8')
)
// <chip ... pinLabels={pinLabels} schPortArrangement={schPortArrangement} />
```

### How pin angles map to schematic sides

KiCad stores the angle the pin stub *points*; the connection end is on the opposite edge:

| KiCad angle | Pin side |
|---|---|
| 0° (stub → right) | **left** |
| 180° (stub → left) | **right** |
| 90° (stub → up) | **bottom** |
| 270° (stub → down) | **top** |

Multi-unit symbols that repeat the same physical pin are deduplicated by pin number.

### Files changed

- **`src/parse-kicad-sym-to-tscircuit.ts`** — new parser using the existing `s-expression` dependency
- **`src/index.ts`** — exports `parseKicadSymToTscircuit` + types
- **`src/site/App.tsx`** — three workflows:
  - `.kicad_mod` only — existing behaviour unchanged
  - `.kicad_sym` only — displays `pinLabels` + `schPortArrangement` JSON output
  - `.kicad_mod` + `.kicad_sym` combined — enhances circuit JSON with sym data
- **`tests/kicad-sym-parser.test.ts`** — 5 tests (NE555 pinLabels, side assignment, `symbolName` selection, unknown-name error, inline two-pin passive)
- **`tests/data/NE555.kicad_sym`** — NE555 timer test fixture

### Test results

```
27 pass  0 fail   (all 22 existing tests still pass, zero type errors)
```

---
/claim #114