### PR TITLE
Accept KiCad symbol files for schematic metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
 export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"
+export { parseKicadSymToSchematicMetadata } from "./parse-kicad-sym-to-schematic-metadata"

--- a/src/parse-kicad-mod-to-circuit-json.ts
+++ b/src/parse-kicad-mod-to-circuit-json.ts
@@ -1,12 +1,51 @@
 import type { AnyCircuitElement } from "circuit-json"
-import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 import { convertKicadJsonToTsCircuitSoup as convertKicadJsonToCircuitJson } from "./convert-kicad-json-to-tscircuit-soup"
+import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
+import {
+  type KicadSymSchematicMetadata,
+  parseKicadSymToSchematicMetadata,
+} from "./parse-kicad-sym-to-schematic-metadata"
+
+const applySchematicMetadata = (
+  circuitJson: AnyCircuitElement[],
+  schematicMetadata?: KicadSymSchematicMetadata,
+) => {
+  if (!schematicMetadata) return circuitJson
+
+  const schematicComponent = circuitJson.find(
+    (elm: any) => elm.type === "schematic_component",
+  ) as any
+  if (schematicComponent) {
+    schematicComponent.port_arrangement = schematicMetadata.port_arrangement
+    schematicComponent.port_labels = schematicMetadata.port_labels
+  }
+
+  for (const elm of circuitJson as any[]) {
+    if (elm.type !== "source_port") continue
+    const portName = `${elm.name}`
+    const label =
+      schematicMetadata.port_labels?.[portName] ??
+      (elm.pin_number !== undefined
+        ? schematicMetadata.port_labels?.[`${elm.pin_number}`]
+        : undefined)
+    if (!label) continue
+    elm.pin_label = label
+    elm.port_hints =
+      label !== portName ? [portName, label] : (elm.port_hints ?? [portName])
+  }
+
+  return circuitJson
+}
 
 export const parseKicadModToCircuitJson = async (
   kicadMod: string,
+  options: { kicadSym?: string } = {},
 ): Promise<AnyCircuitElement[]> => {
   const kicadJson = parseKicadModToKicadJson(kicadMod)
+  const schematicMetadata = options.kicadSym
+    ? parseKicadSymToSchematicMetadata(options.kicadSym)
+    : undefined
 
   const circuitJson = await convertKicadJsonToCircuitJson(kicadJson)
-  return circuitJson as any
+  return applySchematicMetadata(circuitJson as any, schematicMetadata) as any
 }

--- a/src/parse-kicad-sym-to-schematic-metadata.ts
+++ b/src/parse-kicad-sym-to-schematic-metadata.ts
@@ -1,0 +1,162 @@
+import parseSExpression from "s-expression"
+
+export interface KicadSymSchematicMetadata {
+  port_arrangement?: {
+    left_side?: {
+      pins: number[]
+      direction?: "top-to-bottom" | "bottom-to-top"
+    }
+    right_side?: {
+      pins: number[]
+      direction?: "top-to-bottom" | "bottom-to-top"
+    }
+    top_side?: {
+      pins: number[]
+      direction?: "left-to-right" | "right-to-left"
+    }
+    bottom_side?: {
+      pins: number[]
+      direction?: "left-to-right" | "right-to-left"
+    }
+  }
+  port_labels?: Record<string, string>
+}
+
+interface ParsedPin {
+  number: number
+  name: string
+  x: number
+  y: number
+  rotation: number
+}
+
+const toValue = (value: any) => value?.valueOf?.() ?? value
+
+const findRows = (node: any, rowName: string, rows: any[][] = []) => {
+  if (!Array.isArray(node)) return rows
+  if (toValue(node[0]) === rowName) {
+    rows.push(node)
+  }
+  for (const child of node) {
+    findRows(child, rowName, rows)
+  }
+  return rows
+}
+
+const getChildRow = (row: any[], name: string) =>
+  row.find((child) => Array.isArray(child) && toValue(child[0]) === name)
+
+const getStringChild = (row: any[], name: string) => {
+  const child = getChildRow(row, name)
+  if (!child) return undefined
+  const value = toValue(child[1])
+  return value === undefined ? undefined : `${value}`
+}
+
+const getAt = (row: any[]) => {
+  const child = getChildRow(row, "at")
+  if (!child) return undefined
+  const nums = child
+    .slice(1)
+    .map((value: any) => Number.parseFloat(`${toValue(value)}`))
+    .filter((value: number) => Number.isFinite(value))
+  if (nums.length < 2) return undefined
+  return {
+    x: nums[0]!,
+    y: nums[1]!,
+    rotation: nums[2] ?? 0,
+  }
+}
+
+const normalizeRotation = (rotation: number) => {
+  const normalized = ((rotation % 360) + 360) % 360
+  if (normalized >= 315 || normalized < 45) return 0
+  if (normalized >= 45 && normalized < 135) return 90
+  if (normalized >= 135 && normalized < 225) return 180
+  return 270
+}
+
+const pinSideFromRotation = (rotation: number) => {
+  switch (normalizeRotation(rotation)) {
+    case 0:
+      return "left_side"
+    case 180:
+      return "right_side"
+    case 90:
+      return "bottom_side"
+    case 270:
+      return "top_side"
+  }
+}
+
+export const parseKicadSymToSchematicMetadata = (
+  fileContent: string,
+): KicadSymSchematicMetadata => {
+  const root = parseSExpression(fileContent)
+  const pins: ParsedPin[] = []
+
+  for (const pinRow of findRows(root, "pin")) {
+    const numberText = getStringChild(pinRow, "number")
+    const name = getStringChild(pinRow, "name")
+    const at = getAt(pinRow)
+    const number =
+      numberText !== undefined ? Number.parseInt(numberText, 10) : Number.NaN
+    if (!Number.isFinite(number) || !name || !at) continue
+    pins.push({ number, name, ...at })
+  }
+
+  const uniquePins = [...new Map(pins.map((pin) => [pin.number, pin])).values()]
+  const grouped = {
+    left_side: [] as ParsedPin[],
+    right_side: [] as ParsedPin[],
+    top_side: [] as ParsedPin[],
+    bottom_side: [] as ParsedPin[],
+  }
+
+  for (const pin of uniquePins) {
+    grouped[pinSideFromRotation(pin.rotation)].push(pin)
+  }
+
+  const port_arrangement: KicadSymSchematicMetadata["port_arrangement"] = {}
+
+  if (grouped.left_side.length > 0) {
+    port_arrangement.left_side = {
+      pins: grouped.left_side
+        .sort((a, b) => b.y - a.y)
+        .map((pin) => pin.number),
+      direction: "top-to-bottom",
+    }
+  }
+  if (grouped.right_side.length > 0) {
+    port_arrangement.right_side = {
+      pins: grouped.right_side
+        .sort((a, b) => b.y - a.y)
+        .map((pin) => pin.number),
+      direction: "top-to-bottom",
+    }
+  }
+  if (grouped.top_side.length > 0) {
+    port_arrangement.top_side = {
+      pins: grouped.top_side.sort((a, b) => a.x - b.x).map((pin) => pin.number),
+      direction: "left-to-right",
+    }
+  }
+  if (grouped.bottom_side.length > 0) {
+    port_arrangement.bottom_side = {
+      pins: grouped.bottom_side
+        .sort((a, b) => a.x - b.x)
+        .map((pin) => pin.number),
+      direction: "left-to-right",
+    }
+  }
+
+  const port_labels = Object.fromEntries(
+    uniquePins.map((pin) => [String(pin.number), pin.name]),
+  )
+
+  return {
+    port_arrangement:
+      Object.keys(port_arrangement).length > 0 ? port_arrangement : undefined,
+    port_labels: Object.keys(port_labels).length > 0 ? port_labels : undefined,
+  }
+}

--- a/src/site/App.tsx
+++ b/src/site/App.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useState, useRef } from "react"
-import { useStore } from "./use-store"
-import { Download, FileSearch } from "lucide-react"
-import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import { createSnippetUrl } from "@tscircuit/create-snippet-url"
 import { CircuitJsonPreview } from "@tscircuit/runframe"
 import { convertCircuitJsonToTscircuit } from "circuit-json-to-tscircuit"
-import { createSnippetUrl } from "@tscircuit/create-snippet-url"
+import { Download, FileSearch } from "lucide-react"
+import { useCallback, useRef, useState } from "react"
+import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import { useStore } from "./use-store"
 
 export const App = () => {
   const [error, setError] = useState<string | null>(null)
@@ -26,7 +26,9 @@ export const App = () => {
     setError(null)
     let circuitJson: any
     try {
-      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod, {
+        kicadSym: filesAdded.kicad_sym,
+      })
       updateCircuitJson(circuitJson as any)
     } catch (err: any) {
       setError(`Error parsing KiCad Mod file: ${err.toString()}`)
@@ -55,7 +57,11 @@ export const App = () => {
         file.trim().startsWith("(footprint")
       ) {
         addFile("kicad_mod", file)
-      } else if (fileName.endsWith(".kicad_sym")) {
+      } else if (
+        fileName.endsWith(".kicad_sym") ||
+        file.trim().startsWith("(kicad_symbol_lib") ||
+        file.trim().startsWith("(symbol")
+      ) {
         addFile("kicad_sym", file)
       } else {
         setError("Unsupported file type")
@@ -84,7 +90,10 @@ export const App = () => {
       if (!content) return
       if (content.trim().startsWith("(footprint")) {
         addDroppedFile("kicad_mod", content)
-      } else if (content.trim().startsWith("(symbol")) {
+      } else if (
+        content.trim().startsWith("(kicad_symbol_lib") ||
+        content.trim().startsWith("(symbol")
+      ) {
         addDroppedFile("kicad_sym", content)
       } else {
         setError("Unsupported file type (file an issue if we're wrong)")
@@ -151,6 +160,16 @@ export const App = () => {
                 {filesAdded.kicad_mod ? "✅" : "❌"}
               </span>
               <span className="text-gray-300">KiCad Mod File</span>
+            </div>
+            <div className="flex items-center gap-2 bg-gray-800/50 p-3 rounded-md">
+              <span
+                className={
+                  filesAdded.kicad_sym ? "text-green-500" : "text-gray-500"
+                }
+              >
+                {filesAdded.kicad_sym ? "✅" : "○"}
+              </span>
+              <span className="text-gray-300">KiCad Sym File (optional)</span>
             </div>
           </div>
           <div className="flex justify-center items-center gap-2">

--- a/tests/kicad-sym-schematic-metadata.test.ts
+++ b/tests/kicad-sym-schematic-metadata.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test"
+import {
+  parseKicadModToCircuitJson,
+  parseKicadSymToSchematicMetadata,
+} from "src"
+
+const kicadMod = `(footprint "Demo:Connector"
+  (version 20240108)
+  (generator "test")
+  (layer "F.Cu")
+  (fp_text reference "J1" (at 0 0 0) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+  (pad "1" smd rect (at -1 0 0) (size 1 1) (layers "F.Cu"))
+  (pad "2" smd rect (at 1 0 0) (size 1 1) (layers "F.Cu"))
+  (pad "3" smd rect (at 0 1 0) (size 1 1) (layers "F.Cu"))
+)`
+
+const kicadSym = `(kicad_symbol_lib
+  (version 20231120)
+  (generator "test")
+  (symbol "Demo_Connector"
+    (property "Reference" "J" (at 0 0 0))
+    (symbol "Demo_Connector_0_1"
+      (pin passive line (at -5 2.54 0) (length 2.54)
+        (name "VCC" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27)))))
+      (pin passive line (at 5 0 180) (length 2.54)
+        (name "GND" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27)))))
+      (pin passive line (at 0 -5 90) (length 2.54)
+        (name "IO" (effects (font (size 1.27 1.27))))
+        (number "3" (effects (font (size 1.27 1.27)))))
+    )
+  )
+)`
+
+test("parses kicad_sym pins into schematic metadata", () => {
+  expect(parseKicadSymToSchematicMetadata(kicadSym)).toEqual({
+    port_arrangement: {
+      left_side: { pins: [1], direction: "top-to-bottom" },
+      right_side: { pins: [2], direction: "top-to-bottom" },
+      bottom_side: { pins: [3], direction: "left-to-right" },
+    },
+    port_labels: {
+      "1": "VCC",
+      "2": "GND",
+      "3": "IO",
+    },
+  })
+})
+
+test("adds optional kicad_sym schematic arrangement and labels", async () => {
+  const circuitJson = (await parseKicadModToCircuitJson(kicadMod, {
+    kicadSym,
+  })) as any[]
+  const schematicComponent = circuitJson.find(
+    (elm) => elm.type === "schematic_component",
+  )
+  const sourcePort1 = circuitJson.find(
+    (elm) => elm.type === "source_port" && elm.name === "1",
+  )
+
+  expect(schematicComponent.port_arrangement).toEqual({
+    left_side: { pins: [1], direction: "top-to-bottom" },
+    right_side: { pins: [2], direction: "top-to-bottom" },
+    bottom_side: { pins: [3], direction: "left-to-right" },
+  })
+  expect(schematicComponent.port_labels).toEqual({
+    "1": "VCC",
+    "2": "GND",
+    "3": "IO",
+  })
+  expect(sourcePort1.pin_label).toBe("VCC")
+  expect(sourcePort1.port_hints).toEqual(["1", "VCC"])
+})
+
+test("keeps footprint-only schematic output unchanged", async () => {
+  const circuitJson = (await parseKicadModToCircuitJson(kicadMod)) as any[]
+  const schematicComponent = circuitJson.find(
+    (elm) => elm.type === "schematic_component",
+  )
+  const sourcePort1 = circuitJson.find(
+    (elm) => elm.type === "source_port" && elm.name === "1",
+  )
+
+  expect(schematicComponent.port_arrangement).toBeUndefined()
+  expect(schematicComponent.port_labels).toBeUndefined()
+  expect(sourcePort1.pin_label).toBe("pin1")
+  expect(sourcePort1.port_hints).toEqual(["1"])
+})


### PR DESCRIPTION
## Summary

- Add a KiCad symbol parser that extracts pin numbers, labels, positions, and side/orientation into schematic metadata
- Let `parseKicadModToCircuitJson` accept an optional `kicadSym` string and apply `port_arrangement` / `port_labels` to the generated schematic component
- Thread optional `.kicad_sym` files through the web viewer so schematic output can use richer symbol labels instead of generic footprint-only labels
- Add regression coverage for symbol metadata parsing, optional symbol-enhanced output, and unchanged footprint-only behavior

## Verification

- `./node_modules/.bin/biome check src/parse-kicad-sym-to-schematic-metadata.ts src/parse-kicad-mod-to-circuit-json.ts src/index.ts src/site/App.tsx tests/kicad-sym-schematic-metadata.test.ts`
- `npm run build:lib` *(local verification used `typescript@5.6.3 --no-save` because the repo does not list `typescript`; using the latest TypeScript 6 prerelease failed on the existing `baseUrl` deprecation)*
- `npm run build:site`

/claim #114