### PR TITLE
feat: support kicad_sym schematic metadata

### DIFF
--- a/src/convert-kicad-json-to-tscircuit-soup.ts
+++ b/src/convert-kicad-json-to-tscircuit-soup.ts
@@ -163,7 +163,6 @@ export const convertKicadJsonToTsCircuitSoup = async (
       }
     }
   }
-
   // Create source_port elements
   let sourcePortId = 0
   const portNameToSourcePortId = new Map<string, string>()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
+export {
+  parseKicadSymToCircuitJson,
+  parseKicadSymToSchematicMetadata as parseKicadSymMetadata,
+  applyKicadSymToCircuitJson,
+} from "./parse-kicad-sym-to-kicad-json"
 export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"

--- a/src/parse-kicad-mod-to-circuit-json.ts
+++ b/src/parse-kicad-mod-to-circuit-json.ts
@@ -1,12 +1,17 @@
 import type { AnyCircuitElement } from "circuit-json"
-import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 import { convertKicadJsonToTsCircuitSoup as convertKicadJsonToCircuitJson } from "./convert-kicad-json-to-tscircuit-soup"
+import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
+import { applyKicadSymToCircuitJson } from "./parse-kicad-sym-to-kicad-json"
 
 export const parseKicadModToCircuitJson = async (
   kicadMod: string,
+  kicadSym?: string,
 ): Promise<AnyCircuitElement[]> => {
   const kicadJson = parseKicadModToKicadJson(kicadMod)
 
-  const circuitJson = await convertKicadJsonToCircuitJson(kicadJson)
+  let circuitJson = await convertKicadJsonToCircuitJson(kicadJson)
+  if (kicadSym) {
+    circuitJson = applyKicadSymToCircuitJson(circuitJson, kicadSym)
+  }
   return circuitJson as any
 }

--- a/src/parse-kicad-sym-to-kicad-json.ts
+++ b/src/parse-kicad-sym-to-kicad-json.ts
@@ -1,0 +1,275 @@
+import type { AnyCircuitElement } from "circuit-json"
+import parseSExpression from "s-expression"
+
+export interface KicadSymSchematicMetadata {
+  port_arrangement?: {
+    left_side?: {
+      pins: number[]
+      direction?: "top-to-bottom" | "bottom-to-top"
+    }
+    right_side?: {
+      pins: number[]
+      direction?: "top-to-bottom" | "bottom-to-top"
+    }
+    top_side?: {
+      pins: number[]
+      direction?: "left-to-right" | "right-to-left"
+    }
+    bottom_side?: {
+      pins: number[]
+      direction?: "left-to-right" | "right-to-left"
+    }
+  }
+  port_labels?: Record<string, string>
+}
+
+export type KicadSymMetadata = KicadSymSchematicMetadata
+
+type ParsedPin = {
+  number: number
+  name: string
+  x: number
+  y: number
+  rotation: number
+}
+
+const toValue = (value: any) => value?.valueOf?.() ?? value
+
+const findRows = (node: any, rowName: string, rows: any[][] = []) => {
+  if (!Array.isArray(node)) return rows
+  if (toValue(node[0]) === rowName) rows.push(node)
+
+  for (const child of node) {
+    findRows(child, rowName, rows)
+  }
+
+  return rows
+}
+
+const getChildRow = (row: any[], name: string) =>
+  row.find((child) => Array.isArray(child) && toValue(child[0]) === name)
+
+const getStringChild = (row: any[], name: string) => {
+  const child = getChildRow(row, name)
+  if (!child) return undefined
+  const value = toValue(child[1])
+  return value === undefined ? undefined : `${value}`
+}
+
+const getAt = (row: any[]) => {
+  const child = getChildRow(row, "at")
+  if (!child) return undefined
+
+  const nums = child
+    .slice(1)
+    .map((value: any) => Number.parseFloat(`${toValue(value)}`))
+    .filter((value: number) => Number.isFinite(value))
+
+  if (nums.length < 2) return undefined
+
+  return {
+    x: nums[0]!,
+    y: nums[1]!,
+    rotation: nums[2] ?? 0,
+  }
+}
+
+const normalizeRotation = (rotation: number) => ((rotation % 360) + 360) % 360
+
+const cardinalRotation = (rotation: number) => {
+  const normalized = normalizeRotation(rotation)
+  if (normalized >= 315 || normalized < 45) return 0
+  if (normalized >= 45 && normalized < 135) return 90
+  if (normalized >= 135 && normalized < 225) return 180
+  return 270
+}
+
+const pinSideFromRotation = (rotation: number) => {
+  switch (cardinalRotation(rotation)) {
+    case 0:
+      return "left_side"
+    case 180:
+      return "right_side"
+    case 90:
+      return "bottom_side"
+    case 270:
+      return "top_side"
+  }
+}
+
+const parsePin = (row: any[]): ParsedPin | undefined => {
+  const at = getAt(row)
+  const numberText = getStringChild(row, "number")
+  const name = getStringChild(row, "name") ?? ""
+
+  if (!at || !numberText) return undefined
+
+  const number = Number.parseInt(numberText, 10)
+  if (!Number.isFinite(number)) return undefined
+
+  return {
+    number,
+    name,
+    ...at,
+  }
+}
+
+const getSortedPinsForSide = (
+  side: keyof NonNullable<KicadSymSchematicMetadata["port_arrangement"]>,
+) => {
+  if (side === "left_side" || side === "right_side") {
+    return (a: ParsedPin, b: ParsedPin) => b.y - a.y
+  }
+  return (a: ParsedPin, b: ParsedPin) => a.x - b.x
+}
+
+export const parseKicadSymToSchematicMetadata = (
+  fileContent: string,
+): KicadSymSchematicMetadata => {
+  const root = parseSExpression(fileContent)
+  const pins = findRows(root, "pin")
+    .map(parsePin)
+    .filter((pin): pin is ParsedPin => Boolean(pin))
+
+  const pinsBySide: Record<
+    "left_side" | "right_side" | "top_side" | "bottom_side",
+    ParsedPin[]
+  > = {
+    left_side: [],
+    right_side: [],
+    top_side: [],
+    bottom_side: [],
+  }
+  const port_labels: Record<string, string> = {}
+
+  for (const pin of pins) {
+    pinsBySide[pinSideFromRotation(pin.rotation)].push(pin)
+    if (pin.name && pin.name !== "~") {
+      port_labels[String(pin.number)] = pin.name
+    }
+  }
+
+  const port_arrangement: NonNullable<
+    KicadSymSchematicMetadata["port_arrangement"]
+  > = {}
+
+  for (const side of Object.keys(pinsBySide) as Array<
+    keyof typeof pinsBySide
+  >) {
+    const sortedPins = pinsBySide[side]
+      .slice()
+      .sort(getSortedPinsForSide(side))
+      .map((pin) => pin.number)
+
+    if (sortedPins.length === 0) continue
+
+    port_arrangement[side] = {
+      pins: sortedPins,
+      direction:
+        side === "left_side" || side === "right_side"
+          ? "top-to-bottom"
+          : "left-to-right",
+    } as any
+  }
+
+  return {
+    port_arrangement:
+      Object.keys(port_arrangement).length > 0 ? port_arrangement : undefined,
+    port_labels: Object.keys(port_labels).length > 0 ? port_labels : undefined,
+  }
+}
+
+export const parseKicadSymToCircuitJson = async (
+  fileContent: string,
+): Promise<AnyCircuitElement[]> => {
+  const schematicMetadata = parseKicadSymToSchematicMetadata(fileContent)
+  const pinNumbers = [
+    ...new Set(
+      [
+        ...Object.values(schematicMetadata.port_arrangement ?? {}).flatMap(
+          (side) => side.pins,
+        ),
+        ...Object.keys(schematicMetadata.port_labels ?? {}).map((pin) =>
+          Number(pin),
+        ),
+      ].filter((pinNumber) => Number.isFinite(pinNumber)),
+    ),
+  ].sort((a, b) => a - b)
+
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      supplier_part_numbers: {},
+    } as any,
+    {
+      type: "schematic_component",
+      schematic_component_id: "schematic_component_0",
+      source_component_id: "source_component_0",
+      center: { x: 0, y: 0 },
+      rotation: 0,
+      size: { width: 0, height: 0 },
+      ...schematicMetadata,
+    } as any,
+  ]
+
+  for (const pinNumber of pinNumbers) {
+    const source_port_id = `source_port_${pinNumber}`
+    const pin_label = schematicMetadata.port_labels?.[`${pinNumber}`]
+
+    circuitJson.push({
+      type: "source_port",
+      source_port_id,
+      source_component_id: "source_component_0",
+      name: `${pinNumber}`,
+      port_hints: pin_label ? [`${pinNumber}`, pin_label] : [`${pinNumber}`],
+      pin_number: pinNumber,
+      pin_label,
+    } as any)
+    circuitJson.push({
+      type: "schematic_port",
+      schematic_port_id: `schematic_port_${pinNumber}`,
+      source_port_id,
+      schematic_component_id: "schematic_component_0",
+      center: { x: 0, y: 0 },
+    } as any)
+  }
+
+  return circuitJson
+}
+
+export const applyKicadSymToCircuitJson = (
+  circuitJson: AnyCircuitElement[],
+  kicadSym: string,
+): AnyCircuitElement[] => {
+  const schematicMetadata = parseKicadSymToSchematicMetadata(kicadSym)
+
+  return circuitJson.map((element: any) => {
+    if (element.type === "schematic_component") {
+      return {
+        ...element,
+        port_arrangement: schematicMetadata.port_arrangement,
+        port_labels: schematicMetadata.port_labels,
+      }
+    }
+
+    if (element.type === "source_port" && schematicMetadata.port_labels) {
+      const pinKey =
+        element.pin_number !== undefined
+          ? `${element.pin_number}`
+          : element.name
+      const pinLabel = schematicMetadata.port_labels[pinKey]
+      if (!pinLabel) return element
+
+      return {
+        ...element,
+        pin_label: pinLabel,
+        port_hints: [...new Set([...(element.port_hints ?? []), pinLabel])],
+      }
+    }
+
+    return element
+  })
+}
+
+export const parseKicadSymMetadata = parseKicadSymToSchematicMetadata

--- a/src/site/App.tsx
+++ b/src/site/App.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useState, useRef } from "react"
-import { useStore } from "./use-store"
-import { Download, FileSearch } from "lucide-react"
-import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import { createSnippetUrl } from "@tscircuit/create-snippet-url"
 import { CircuitJsonPreview } from "@tscircuit/runframe"
 import { convertCircuitJsonToTscircuit } from "circuit-json-to-tscircuit"
-import { createSnippetUrl } from "@tscircuit/create-snippet-url"
+import { Download, FileSearch } from "lucide-react"
+import { useCallback, useRef, useState } from "react"
+import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import { parseKicadSymToCircuitJson } from "src/parse-kicad-sym-to-kicad-json"
+import { useStore } from "./use-store"
 
 export const App = () => {
   const [error, setError] = useState<string | null>(null)
@@ -19,17 +20,22 @@ export const App = () => {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const handleProcessAndViewFiles = useCallback(async () => {
-    if (!filesAdded.kicad_mod) {
-      setError("No KiCad Mod file added")
+    if (!filesAdded.kicad_mod && !filesAdded.kicad_sym) {
+      setError("No KiCad file added")
       return
     }
     setError(null)
     let circuitJson: any
     try {
-      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+      circuitJson = filesAdded.kicad_mod
+        ? await parseKicadModToCircuitJson(
+            filesAdded.kicad_mod,
+            filesAdded.kicad_sym,
+          )
+        : await parseKicadSymToCircuitJson(filesAdded.kicad_sym!)
       updateCircuitJson(circuitJson as any)
     } catch (err: any) {
-      setError(`Error parsing KiCad Mod file: ${err.toString()}`)
+      setError(`Error parsing KiCad file: ${err.toString()}`)
       return
     }
 
@@ -151,6 +157,16 @@ export const App = () => {
                 {filesAdded.kicad_mod ? "✅" : "❌"}
               </span>
               <span className="text-gray-300">KiCad Mod File</span>
+            </div>
+            <div className="flex items-center gap-2 bg-gray-800/50 p-3 rounded-md">
+              <span
+                className={
+                  filesAdded.kicad_sym ? "text-green-500" : "text-red-500"
+                }
+              >
+                {filesAdded.kicad_sym ? "✅" : "❌"}
+              </span>
+              <span className="text-gray-300">KiCad Sym File</span>
             </div>
           </div>
           <div className="flex justify-center items-center gap-2">

--- a/tests/kicad-sym-port-arrangement.test.ts
+++ b/tests/kicad-sym-port-arrangement.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs"
+import { join } from "node:path"
+import {
+  parseKicadModToCircuitJson,
+  parseKicadSymMetadata,
+  parseKicadSymToCircuitJson,
+} from "src"
+
+const symbolFixture = `
+(kicad_symbol_lib
+  (version 20211014)
+  (generator "kicad_symbol_editor")
+  (symbol "Demo:Ported"
+    (pin input line (at -10 10 0) (length 2.54)
+      (name "IN" (effects (font (size 1.27 1.27))))
+      (number "1" (effects (font (size 1.27 1.27)))))
+    (pin output line (at 10 10 180) (length 2.54)
+      (name "OUT" (effects (font (size 1.27 1.27))))
+      (number "2" (effects (font (size 1.27 1.27)))))
+    (pin power_in line (at 0 20 270) (length 2.54)
+      (name "VCC" (effects (font (size 1.27 1.27))))
+      (number "3" (effects (font (size 1.27 1.27)))))
+    (pin passive line (at 0 -20 90) (length 2.54)
+      (name "GND" (effects (font (size 1.27 1.27))))
+      (number "4" (effects (font (size 1.27 1.27)))))
+  )
+)
+`
+
+test("kicad_sym metadata maps pins into stable schematic sides", () => {
+  const metadata = parseKicadSymMetadata(symbolFixture)
+
+  expect(metadata.port_labels).toEqual({
+    1: "IN",
+    2: "OUT",
+    3: "VCC",
+    4: "GND",
+  })
+  expect(metadata.port_arrangement).toEqual({
+    left_side: { pins: [1], direction: "top-to-bottom" },
+    right_side: { pins: [2], direction: "top-to-bottom" },
+    top_side: { pins: [3], direction: "left-to-right" },
+    bottom_side: { pins: [4], direction: "left-to-right" },
+  })
+})
+
+test("kicad_sym-only input produces schematic ports and labels", async () => {
+  const circuitJson = (await parseKicadSymToCircuitJson(symbolFixture)) as any[]
+  const schematicComponent = circuitJson.find(
+    (element) => element.type === "schematic_component",
+  )
+  const sourcePorts = circuitJson.filter(
+    (element) => element.type === "source_port",
+  )
+
+  expect(schematicComponent?.port_labels).toEqual({
+    1: "IN",
+    2: "OUT",
+    3: "VCC",
+    4: "GND",
+  })
+  expect(schematicComponent?.port_arrangement).toEqual({
+    left_side: { pins: [1], direction: "top-to-bottom" },
+    right_side: { pins: [2], direction: "top-to-bottom" },
+    top_side: { pins: [3], direction: "left-to-right" },
+    bottom_side: { pins: [4], direction: "left-to-right" },
+  })
+  expect(sourcePorts.map((port) => port.pin_label)).toEqual([
+    "IN",
+    "OUT",
+    "VCC",
+    "GND",
+  ])
+})
+
+test("kicad_mod input can be enriched by kicad_sym labels", async () => {
+  const footprintPath = join(
+    import.meta.dirname,
+    "./fixtures/SimpleSmd.kicad_mod",
+  )
+  const footprint = fs.readFileSync(footprintPath, "utf8")
+  const enriched = (await parseKicadModToCircuitJson(
+    footprint,
+    symbolFixture,
+  )) as any[]
+  const sourcePort = enriched.find(
+    (element) => element.type === "source_port" && element.name === "1",
+  )
+  const schematicComponent = enriched.find(
+    (element) => element.type === "schematic_component",
+  )
+
+  expect(sourcePort?.pin_label).toBe("IN")
+  expect(sourcePort?.port_hints).toEqual(["1", "IN"])
+  expect(schematicComponent?.port_labels?.["1"]).toBe("IN")
+})


### PR DESCRIPTION
## Summary
- Parse standalone `.kicad_sym` files into schematic metadata
- Apply symbol pin labels and port arrangement to combined footprint+symbol conversion
- Preserve the existing `.kicad_mod`-only path

## Verification
- Direct runtime checks for symbol-only parsing, side mapping, and combined overlay
- `npx biome check src/parse-kicad-sym-to-kicad-json.ts src/parse-kicad-mod-to-circuit-json.ts src/site/App.tsx src/index.ts tests/kicad-sym-port-arrangement.test.ts`
- `npm run build:site`
- `npm run build:lib` with local TypeScript 5.6.3 for the repo’s current TS 6 compatibility issue

/claim #114
