### PR TITLE
Add KiCad symbol metadata for schematic ports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
+export { parseKicadSymToSymbolMetadata } from "./parse-kicad-sym-to-symbol-metadata"
 export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"

--- a/src/parse-kicad-mod-to-circuit-json.ts
+++ b/src/parse-kicad-mod-to-circuit-json.ts
@@ -1,12 +1,41 @@
 import type { AnyCircuitElement } from "circuit-json"
 import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 import { convertKicadJsonToTsCircuitSoup as convertKicadJsonToCircuitJson } from "./convert-kicad-json-to-tscircuit-soup"
+import {
+  getPortLabelsFromKicadPins,
+  getSchPortArrangementFromKicadPins,
+  parseKicadSymToSymbolMetadata,
+} from "./parse-kicad-sym-to-symbol-metadata"
+
+export interface ParseKicadModToCircuitJsonOptions {
+  kicadSym?: string
+}
 
 export const parseKicadModToCircuitJson = async (
   kicadMod: string,
+  options: ParseKicadModToCircuitJsonOptions = {},
 ): Promise<AnyCircuitElement[]> => {
   const kicadJson = parseKicadModToKicadJson(kicadMod)
 
   const circuitJson = await convertKicadJsonToCircuitJson(kicadJson)
+
+  if (options.kicadSym) {
+    const symbolMetadata = parseKicadSymToSymbolMetadata(options.kicadSym)
+    const schematicComponent = circuitJson.find(
+      (elm) => elm.type === "schematic_component",
+    ) as any
+
+    if (schematicComponent) {
+      schematicComponent.symbol_name = symbolMetadata.symbolName
+      schematicComponent.port_arrangement = getSchPortArrangementFromKicadPins(
+        symbolMetadata.pins,
+      )
+      schematicComponent.port_labels = getPortLabelsFromKicadPins(
+        symbolMetadata.pins,
+      )
+      schematicComponent.is_box_with_pins = true
+    }
+  }
+
   return circuitJson as any
 }

--- a/src/parse-kicad-sym-to-symbol-metadata.ts
+++ b/src/parse-kicad-sym-to-symbol-metadata.ts
@@ -1,0 +1,142 @@
+import parseSExpression from "s-expression"
+
+export interface KicadSymbolPinMetadata {
+  number: string
+  name?: string
+  x: number
+  y: number
+  rotation: number
+}
+
+export interface KicadSymbolMetadata {
+  symbolName: string
+  pins: KicadSymbolPinMetadata[]
+}
+
+const rowName = (row: any) => row?.[0]?.valueOf?.() ?? row?.[0]
+
+const rowValue = (row: any, index: number) => row?.[index]?.valueOf?.()
+
+const findAttr = (row: any[], attrName: string) =>
+  row.find((child) => Array.isArray(child) && rowName(child) === attrName)
+
+const parseNumber = (value: any) => {
+  const parsed = Number(value?.valueOf?.() ?? value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+const getPinSide = (pin: KicadSymbolPinMetadata) => {
+  const normalizedRotation = ((pin.rotation % 360) + 360) % 360
+
+  if (normalizedRotation === 0) return "left"
+  if (normalizedRotation === 180) return "right"
+  if (normalizedRotation === 90) return "bottom"
+  if (normalizedRotation === 270) return "top"
+
+  const absX = Math.abs(pin.x)
+  const absY = Math.abs(pin.y)
+  if (absX >= absY) return pin.x < 0 ? "left" : "right"
+  return pin.y < 0 ? "bottom" : "top"
+}
+
+const sortPinsBySidePosition = (
+  a: KicadSymbolPinMetadata,
+  b: KicadSymbolPinMetadata,
+) => {
+  const side = getPinSide(a)
+  if (side === "left" || side === "right") {
+    return b.y - a.y || a.x - b.x || a.number.localeCompare(b.number)
+  }
+  return a.x - b.x || b.y - a.y || a.number.localeCompare(b.number)
+}
+
+export const getSchPortArrangementFromKicadPins = (
+  pins: KicadSymbolPinMetadata[],
+) => {
+  const sides = {
+    left: [] as KicadSymbolPinMetadata[],
+    right: [] as KicadSymbolPinMetadata[],
+    top: [] as KicadSymbolPinMetadata[],
+    bottom: [] as KicadSymbolPinMetadata[],
+  }
+
+  for (const pin of pins) {
+    sides[getPinSide(pin)].push(pin)
+  }
+
+  const arrangement: Record<string, { pins: string[]; direction: string }> = {}
+  const sideConfig = [
+    ["left", "left_side", "top-to-bottom"],
+    ["right", "right_side", "top-to-bottom"],
+    ["top", "top_side", "left-to-right"],
+    ["bottom", "bottom_side", "left-to-right"],
+  ] as const
+
+  for (const [side, key, direction] of sideConfig) {
+    const sidePins = sides[side]
+    if (sidePins.length === 0) continue
+    arrangement[key] = {
+      pins: sidePins.sort(sortPinsBySidePosition).map((pin) => pin.number),
+      direction,
+    }
+  }
+
+  return arrangement
+}
+
+export const getPortLabelsFromKicadPins = (pins: KicadSymbolPinMetadata[]) => {
+  const portLabels: Record<string, string> = {}
+
+  for (const pin of pins) {
+    const label = pin.name?.trim()
+    if (!label || label === "~") continue
+    portLabels[pin.number] = label
+  }
+
+  return portLabels
+}
+
+export const parseKicadSymToSymbolMetadata = (
+  fileContent: string,
+): KicadSymbolMetadata => {
+  const root = parseSExpression(fileContent) as any[]
+  const rootName = rowName(root)
+  const symbolRows =
+    rootName === "symbol"
+      ? [root]
+      : root.filter((row) => Array.isArray(row) && rowName(row) === "symbol")
+  const symbolRow =
+    symbolRows.find((row) =>
+      row.some(
+        (child: any) => Array.isArray(child) && rowName(child) === "pin",
+      ),
+    ) ?? symbolRows[0]
+
+  if (!symbolRow) {
+    throw new Error("No symbol found in KiCad symbol file")
+  }
+
+  const symbolName = String(rowValue(symbolRow, 1) ?? "")
+  const pins: KicadSymbolPinMetadata[] = []
+
+  for (const row of symbolRow) {
+    if (!Array.isArray(row) || rowName(row) !== "pin") continue
+
+    const at = findAttr(row, "at")
+    const name = findAttr(row, "name")
+    const number = findAttr(row, "number")
+    const pinNumber = rowValue(number, 1)
+    if (pinNumber === undefined || pinNumber === "") continue
+
+    pins.push({
+      number: String(pinNumber),
+      name:
+        rowValue(name, 1) !== undefined ? String(rowValue(name, 1)) : undefined,
+      x: parseNumber(rowValue(at, 1)),
+      y: parseNumber(rowValue(at, 2)),
+      rotation: parseNumber(rowValue(at, 3)),
+    })
+  }
+
+  return { symbolName, pins }
+}

--- a/src/site/App.tsx
+++ b/src/site/App.tsx
@@ -26,7 +26,9 @@ export const App = () => {
     setError(null)
     let circuitJson: any
     try {
-      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod, {
+        kicadSym: filesAdded.kicad_sym,
+      })
       updateCircuitJson(circuitJson as any)
     } catch (err: any) {
       setError(`Error parsing KiCad Mod file: ${err.toString()}`)
@@ -151,6 +153,18 @@ export const App = () => {
                 {filesAdded.kicad_mod ? "✅" : "❌"}
               </span>
               <span className="text-gray-300">KiCad Mod File</span>
+            </div>
+            <div className="flex items-center gap-2 bg-gray-800/50 p-3 rounded-md">
+              <span
+                className={
+                  filesAdded.kicad_sym ? "text-green-500" : "text-gray-500"
+                }
+              >
+                {filesAdded.kicad_sym ? "✅" : "○"}
+              </span>
+              <span className="text-gray-300">
+                KiCad Symbol File (optional)
+              </span>
             </div>
           </div>
           <div className="flex justify-center items-center gap-2">

--- a/tests/kicad-sym-port-arrangement.test.ts
+++ b/tests/kicad-sym-port-arrangement.test.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "bun:test"
+import { parseKicadModToCircuitJson, parseKicadSymToSymbolMetadata } from "src"
+
+const testFootprint = `(footprint "Test:DIP_4"
+  (version 20240108)
+  (generator "pcbnew")
+  (layer "F.Cu")
+  (pad "1" thru_hole rect (at -3.81 -2.54) (size 1.6 1.6) (drill 0.8) (layers "*.Cu" "*.Mask"))
+  (pad "2" thru_hole circle (at -3.81 2.54) (size 1.6 1.6) (drill 0.8) (layers "*.Cu" "*.Mask"))
+  (pad "3" thru_hole circle (at 3.81 2.54) (size 1.6 1.6) (drill 0.8) (layers "*.Cu" "*.Mask"))
+  (pad "4" thru_hole circle (at 3.81 -2.54) (size 1.6 1.6) (drill 0.8) (layers "*.Cu" "*.Mask"))
+)`
+
+const testSymbol = `(kicad_symbol_lib
+  (version 20231120)
+  (generator "kicad_symbol_editor")
+  (symbol "Device:TEST4"
+    (pin input line (at -5.08 2.54 0) (length 2.54)
+      (name "VCC" (effects (font (size 1.27 1.27))))
+      (number "1" (effects (font (size 1.27 1.27))))
+    )
+    (pin input line (at -5.08 -2.54 0) (length 2.54)
+      (name "GND" (effects (font (size 1.27 1.27))))
+      (number "2" (effects (font (size 1.27 1.27))))
+    )
+    (pin output line (at 5.08 -2.54 180) (length 2.54)
+      (name "SCL" (effects (font (size 1.27 1.27))))
+      (number "3" (effects (font (size 1.27 1.27))))
+    )
+    (pin output line (at 5.08 2.54 180) (length 2.54)
+      (name "SDA" (effects (font (size 1.27 1.27))))
+      (number "4" (effects (font (size 1.27 1.27))))
+    )
+  )
+)`
+
+test("parses KiCad symbol pins into metadata", () => {
+  const metadata = parseKicadSymToSymbolMetadata(testSymbol)
+
+  expect(metadata.symbolName).toBe("Device:TEST4")
+  expect(metadata.pins.map((pin) => pin.number)).toEqual(["1", "2", "3", "4"])
+  expect(metadata.pins.map((pin) => pin.name)).toEqual([
+    "VCC",
+    "GND",
+    "SCL",
+    "SDA",
+  ])
+})
+
+test("adds symbol pin labels and schematic port arrangement when kicad_sym is provided", async () => {
+  const circuitJson = await parseKicadModToCircuitJson(testFootprint, {
+    kicadSym: testSymbol,
+  })
+
+  const schematicComponent = circuitJson.find(
+    (elm) => elm.type === "schematic_component",
+  ) as any
+
+  expect(schematicComponent.symbol_name).toBe("Device:TEST4")
+  expect(schematicComponent.port_labels).toEqual({
+    "1": "VCC",
+    "2": "GND",
+    "3": "SCL",
+    "4": "SDA",
+  })
+  expect(schematicComponent.port_arrangement).toEqual({
+    left_side: { pins: ["1", "2"], direction: "top-to-bottom" },
+    right_side: { pins: ["4", "3"], direction: "top-to-bottom" },
+  })
+})


### PR DESCRIPTION
## Summary
- Add `.kicad_sym` parsing for symbol pins, pin names, pin numbers, and pin positions
- Thread optional symbol metadata into `parseKicadModToCircuitJson` so schematic components receive `symbol_name`, `port_arrangement`, and `port_labels`
- Wire the site UI to pass the optional KiCad symbol file alongside the footprint
- Add regression coverage for generated schematic port arrangement and labels

/claim #114

## Verification
- `bun run build:lib`
- `bun test`
- `bun run format:check`
