### PR TITLE
feat: derive schematic metadata from kicad_sym

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,13 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
 export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"
+export {
+  applyKicadSymMetadataToCircuitJson,
+  parseKicadSymToSchematicMetadata,
+} from "./parse-kicad-sym-to-schematic-metadata"
+export type {
+  CircuitJsonPortArrangement,
+  KicadSymbolSchematicMetadata,
+  SchPortArrangement,
+  SchPortArrangementSide,
+} from "./parse-kicad-sym-to-schematic-metadata"

--- a/src/parse-kicad-sym-to-schematic-metadata.ts
+++ b/src/parse-kicad-sym-to-schematic-metadata.ts
@@ -1,0 +1,263 @@
+import SParseModule from "s-expression"
+
+const SParse = (SParseModule as any).default ?? SParseModule
+
+export type SchPortArrangementSide = {
+  pins: Array<string | number>
+  direction:
+    | "top-to-bottom"
+    | "left-to-right"
+    | "bottom-to-top"
+    | "right-to-left"
+}
+
+export type SchPortArrangement = {
+  leftSide?: SchPortArrangementSide
+  topSide?: SchPortArrangementSide
+  rightSide?: SchPortArrangementSide
+  bottomSide?: SchPortArrangementSide
+}
+
+export type CircuitJsonPortArrangement = {
+  left_side?: SchPortArrangementSide
+  top_side?: SchPortArrangementSide
+  right_side?: SchPortArrangementSide
+  bottom_side?: SchPortArrangementSide
+}
+
+export type KicadSymbolSchematicMetadata = {
+  pinLabels: Record<string, string>
+  schPortArrangement: SchPortArrangement
+  circuitJsonPortArrangement: CircuitJsonPortArrangement
+}
+
+type SExpr = string | number | String | Number | SExpr[]
+
+type KicadSymbolPin = {
+  pinNumber: string
+  pinKey: string
+  label: string
+  x: number
+  y: number
+  rotation: number
+}
+
+const isList = (node: SExpr): node is SExpr[] => Array.isArray(node)
+
+const nodeName = (value: SExpr | undefined): string | undefined => {
+  if (value === undefined) return undefined
+  if (isList(value)) return undefined
+  return String(value)
+}
+
+const asString = (value: SExpr | undefined): string | undefined => {
+  if (value === undefined || isList(value)) return undefined
+  return String(value)
+}
+
+const asNumber = (value: SExpr | undefined): number | undefined => {
+  if (value === undefined || isList(value)) return undefined
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+const findChild = (node: SExpr[], name: string): SExpr[] | undefined =>
+  node.find(
+    (child): child is SExpr[] => isList(child) && nodeName(child[0]) === name,
+  )
+
+const collectNodes = (
+  node: SExpr,
+  name: string,
+  out: SExpr[][] = [],
+): SExpr[][] => {
+  if (!isList(node)) return out
+  if (nodeName(node[0]) === name) out.push(node)
+  for (const child of node) collectNodes(child, name, out)
+  return out
+}
+
+const getTopLevelSymbolNodes = (root: SExpr): SExpr[] => {
+  if (!isList(root)) return []
+  if (nodeName(root[0]) === "symbol") return [root]
+  if (nodeName(root[0]) === "kicad_symbol_lib") {
+    return root.filter(
+      (child): child is SExpr[] =>
+        isList(child) && nodeName(child[0]) === "symbol",
+    )
+  }
+  return root.flatMap((child) => getTopLevelSymbolNodes(child))
+}
+
+const parsePin = (pinNode: SExpr[]): KicadSymbolPin | null => {
+  const atNode = findChild(pinNode, "at")
+  const nameNode = findChild(pinNode, "name")
+  const numberNode = findChild(pinNode, "number")
+  const pinNumber = asString(numberNode?.[1])
+  if (!pinNumber) return null
+
+  const label = asString(nameNode?.[1]) ?? pinNumber
+  const x = asNumber(atNode?.[1]) ?? 0
+  const y = asNumber(atNode?.[2]) ?? 0
+  const rotation = asNumber(atNode?.[3]) ?? 0
+
+  return {
+    pinNumber,
+    pinKey: `pin${pinNumber}`,
+    label: label === "~" ? pinNumber : label,
+    x,
+    y,
+    rotation,
+  }
+}
+
+const chooseSymbolPins = (root: SExpr): KicadSymbolPin[] => {
+  const symbolNodes = getTopLevelSymbolNodes(root)
+  for (const symbolNode of symbolNodes) {
+    const rawPins = collectNodes(symbolNode, "pin")
+    const pins = rawPins
+      .map(parsePin)
+      .filter((pin): pin is KicadSymbolPin => pin !== null)
+    if (pins.length > 0) return pins
+  }
+
+  const rawPins = collectNodes(root, "pin")
+  return rawPins
+    .map(parsePin)
+    .filter((pin): pin is KicadSymbolPin => pin !== null)
+}
+
+type SideName = "leftSide" | "topSide" | "rightSide" | "bottomSide"
+
+const sideForPin = (
+  pin: KicadSymbolPin,
+  centerX: number,
+  centerY: number,
+): SideName => {
+  const dx = pin.x - centerX
+  const dy = pin.y - centerY
+
+  if (Math.abs(dx) > Math.abs(dy)) {
+    return dx < 0 ? "leftSide" : "rightSide"
+  }
+  if (Math.abs(dy) > 0) {
+    return dy < 0 ? "topSide" : "bottomSide"
+  }
+
+  const normalizedRotation = ((pin.rotation % 360) + 360) % 360
+  if (normalizedRotation === 0) return "leftSide"
+  if (normalizedRotation === 180) return "rightSide"
+  if (normalizedRotation === 90) return "bottomSide"
+  return "topSide"
+}
+
+const directionForSide: Record<SideName, SchPortArrangementSide["direction"]> =
+  {
+    leftSide: "top-to-bottom",
+    rightSide: "bottom-to-top",
+    topSide: "left-to-right",
+    bottomSide: "right-to-left",
+  }
+
+const snakeCaseSide = (side: SideName) =>
+  side.replace(/[A-Z]/g, (match) => `_${match.toLowerCase()}`) as
+    | "left_side"
+    | "top_side"
+    | "right_side"
+    | "bottom_side"
+
+export const parseKicadSymToSchematicMetadata = (
+  kicadSymContent: string,
+): KicadSymbolSchematicMetadata | null => {
+  const root = SParse(kicadSymContent) as SExpr
+  const pins = chooseSymbolPins(root)
+  if (pins.length === 0) return null
+
+  const centerX = pins.reduce((sum, pin) => sum + pin.x, 0) / pins.length
+  const centerY = pins.reduce((sum, pin) => sum + pin.y, 0) / pins.length
+  const pinsBySide: Record<SideName, KicadSymbolPin[]> = {
+    leftSide: [],
+    topSide: [],
+    rightSide: [],
+    bottomSide: [],
+  }
+
+  for (const pin of pins) {
+    pinsBySide[sideForPin(pin, centerX, centerY)].push(pin)
+  }
+
+  const schPortArrangement: SchPortArrangement = {}
+  for (const [side, sidePins] of Object.entries(pinsBySide) as Array<
+    [SideName, KicadSymbolPin[]]
+  >) {
+    if (sidePins.length === 0) continue
+    const isVerticalSide = side === "leftSide" || side === "rightSide"
+    const sortedPins = [...sidePins].sort((a, b) =>
+      isVerticalSide ? a.y - b.y : a.x - b.x,
+    )
+    schPortArrangement[side] = {
+      pins: sortedPins.map((pin) => pin.label),
+      direction: directionForSide[side],
+    }
+  }
+
+  const circuitJsonPortArrangement = Object.fromEntries(
+    Object.entries(schPortArrangement).map(([side, arrangement]) => [
+      snakeCaseSide(side as SideName),
+      arrangement,
+    ]),
+  ) as CircuitJsonPortArrangement
+
+  return {
+    pinLabels: Object.fromEntries(
+      pins.map((pin) => [pin.pinKey, pin.label] as const),
+    ),
+    schPortArrangement,
+    circuitJsonPortArrangement,
+  }
+}
+
+export const applyKicadSymMetadataToCircuitJson = (
+  circuitJson: any[],
+  metadata: KicadSymbolSchematicMetadata | null,
+): any[] => {
+  if (!metadata) return circuitJson
+
+  const pinLabelsByNumber = Object.fromEntries(
+    Object.entries(metadata.pinLabels).map(([pinKey, label]) => [
+      pinKey.replace(/^pin/, ""),
+      label,
+    ]),
+  )
+  const sourcePortLabelById = new Map<string, string>()
+
+  for (const element of circuitJson) {
+    if (element?.type !== "source_port") continue
+    const pinNumber =
+      element.pin_number?.toString?.() ?? element.name?.toString?.()
+    const label = pinNumber ? pinLabelsByNumber[pinNumber] : undefined
+    if (!label) continue
+    sourcePortLabelById.set(element.source_port_id, label)
+    element.pin_label = `pin${pinNumber}`
+  }
+
+  for (const element of circuitJson) {
+    if (element?.type === "schematic_component") {
+      element.port_labels = {
+        ...(element.port_labels ?? {}),
+        ...metadata.pinLabels,
+      }
+      element.port_arrangement = {
+        ...(element.port_arrangement ?? {}),
+        ...metadata.circuitJsonPortArrangement,
+      }
+    }
+
+    if (element?.type === "schematic_port") {
+      const label = sourcePortLabelById.get(element.source_port_id)
+      if (label) element.display_pin_label = label
+    }
+  }
+
+  return circuitJson
+}

--- a/src/site/App.tsx
+++ b/src/site/App.tsx
@@ -5,6 +5,22 @@ import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
 import { CircuitJsonPreview } from "@tscircuit/runframe"
 import { convertCircuitJsonToTscircuit } from "circuit-json-to-tscircuit"
 import { createSnippetUrl } from "@tscircuit/create-snippet-url"
+import {
+  applyKicadSymMetadataToCircuitJson,
+  parseKicadSymToSchematicMetadata,
+  type KicadSymbolSchematicMetadata,
+} from "src/parse-kicad-sym-to-schematic-metadata"
+
+const addSchematicMetadataToTscircuitCode = (
+  tscircuitCode: string,
+  metadata: KicadSymbolSchematicMetadata | null,
+) => {
+  if (!metadata) return tscircuitCode
+  return tscircuitCode.replace(
+    "pinLabels={pinLabels}",
+    `pinLabels={pinLabels}\n    schPortArrangement={${JSON.stringify(metadata.schPortArrangement)}}`,
+  )
+}
 
 export const App = () => {
   const [error, setError] = useState<string | null>(null)
@@ -25,8 +41,18 @@ export const App = () => {
     }
     setError(null)
     let circuitJson: any
+    let schematicMetadata: KicadSymbolSchematicMetadata | null = null
     try {
       circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+      if (filesAdded.kicad_sym) {
+        schematicMetadata = parseKicadSymToSchematicMetadata(
+          filesAdded.kicad_sym,
+        )
+        circuitJson = applyKicadSymMetadataToCircuitJson(
+          circuitJson,
+          schematicMetadata,
+        )
+      }
       updateCircuitJson(circuitJson as any)
     } catch (err: any) {
       setError(`Error parsing KiCad Mod file: ${err.toString()}`)
@@ -35,9 +61,13 @@ export const App = () => {
 
     try {
       // Now we convert the circuit json to tscircuit
-      const tscircuit = convertCircuitJsonToTscircuit(circuitJson, {
-        componentName: "MyComponent",
-      })
+      const tscircuit = addSchematicMetadataToTscircuitCode(
+        convertCircuitJsonToTscircuit(circuitJson, {
+          componentName: "MyComponent",
+          pinLabels: schematicMetadata?.pinLabels,
+        }),
+        schematicMetadata,
+      )
       updateTscircuitCode(tscircuit)
     } catch (err: any) {
       setError(
@@ -56,6 +86,10 @@ export const App = () => {
       ) {
         addFile("kicad_mod", file)
       } else if (fileName.endsWith(".kicad_sym")) {
+        addFile("kicad_sym", file)
+      } else if (file.trim().startsWith("(symbol")) {
+        addFile("kicad_sym", file)
+      } else if (file.trim().startsWith("(kicad_symbol_lib")) {
         addFile("kicad_sym", file)
       } else {
         setError("Unsupported file type")
@@ -84,7 +118,10 @@ export const App = () => {
       if (!content) return
       if (content.trim().startsWith("(footprint")) {
         addDroppedFile("kicad_mod", content)
-      } else if (content.trim().startsWith("(symbol")) {
+      } else if (
+        content.trim().startsWith("(symbol") ||
+        content.trim().startsWith("(kicad_symbol_lib")
+      ) {
         addDroppedFile("kicad_sym", content)
       } else {
         setError("Unsupported file type (file an issue if we're wrong)")
@@ -205,11 +242,18 @@ export const App = () => {
                 className="bg-indigo-500 inline-flex items-center text-white p-2 rounded-md"
                 onClick={() => {
                   try {
+                    const schematicMetadata = filesAdded.kicad_sym
+                      ? parseKicadSymToSchematicMetadata(filesAdded.kicad_sym)
+                      : null
                     const code =
                       tscircuitCode ??
-                      convertCircuitJsonToTscircuit(circuitJson, {
-                        componentName: "MyComponent",
-                      })
+                      addSchematicMetadataToTscircuitCode(
+                        convertCircuitJsonToTscircuit(circuitJson, {
+                          componentName: "MyComponent",
+                          pinLabels: schematicMetadata?.pinLabels,
+                        }),
+                        schematicMetadata,
+                      )
                     const blob = new Blob([code], { type: "text/tsx" })
                     const url = URL.createObjectURL(blob)
                     const a = document.createElement("a")

--- a/tests/parse-kicad-sym-to-schematic-metadata.test.ts
+++ b/tests/parse-kicad-sym-to-schematic-metadata.test.ts
@@ -1,0 +1,107 @@
+import { test, expect } from "bun:test"
+import {
+  applyKicadSymMetadataToCircuitJson,
+  parseKicadSymToSchematicMetadata,
+} from "../src/parse-kicad-sym-to-schematic-metadata"
+
+const simpleKicadSym = `
+(kicad_symbol_lib
+  (version 20231120)
+  (generator "test")
+  (symbol "Test:UsbPort"
+    (pin power_in line (at -5.08 -2.54 0) (length 2.54)
+      (name "VBUS" (effects (font (size 1.27 1.27))))
+      (number "1" (effects (font (size 1.27 1.27))))
+    )
+    (pin bidirectional line (at -5.08 0 0) (length 2.54)
+      (name "D+" (effects (font (size 1.27 1.27))))
+      (number "2" (effects (font (size 1.27 1.27))))
+    )
+    (pin bidirectional line (at 5.08 0 180) (length 2.54)
+      (name "D-" (effects (font (size 1.27 1.27))))
+      (number "3" (effects (font (size 1.27 1.27))))
+    )
+    (pin power_in line (at 5.08 2.54 180) (length 2.54)
+      (name "GND" (effects (font (size 1.27 1.27))))
+      (number "4" (effects (font (size 1.27 1.27))))
+    )
+  )
+)
+`
+
+test("parseKicadSymToSchematicMetadata extracts pin labels and port arrangement", () => {
+  expect(parseKicadSymToSchematicMetadata(simpleKicadSym)).toEqual({
+    pinLabels: {
+      pin1: "VBUS",
+      pin2: "D+",
+      pin3: "D-",
+      pin4: "GND",
+    },
+    schPortArrangement: {
+      leftSide: {
+        pins: ["VBUS", "D+"],
+        direction: "top-to-bottom",
+      },
+      rightSide: {
+        pins: ["D-", "GND"],
+        direction: "bottom-to-top",
+      },
+    },
+    circuitJsonPortArrangement: {
+      left_side: {
+        pins: ["VBUS", "D+"],
+        direction: "top-to-bottom",
+      },
+      right_side: {
+        pins: ["D-", "GND"],
+        direction: "bottom-to-top",
+      },
+    },
+  })
+})
+
+test("applyKicadSymMetadataToCircuitJson adds port labels and display pin labels", () => {
+  const metadata = parseKicadSymToSchematicMetadata(simpleKicadSym)
+  const circuitJson = [
+    {
+      type: "schematic_component",
+      schematic_component_id: "schematic_component_0",
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "1",
+      pin_number: 1,
+      pin_label: "pin1",
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "schematic_port_0",
+      source_port_id: "source_port_0",
+      schematic_component_id: "schematic_component_0",
+    },
+  ]
+
+  expect(
+    applyKicadSymMetadataToCircuitJson(circuitJson, metadata),
+  ).toMatchObject([
+    {
+      type: "schematic_component",
+      port_labels: { pin1: "VBUS", pin2: "D+", pin3: "D-", pin4: "GND" },
+      port_arrangement: {
+        left_side: { pins: ["VBUS", "D+"], direction: "top-to-bottom" },
+        right_side: { pins: ["D-", "GND"], direction: "bottom-to-top" },
+      },
+    },
+    {
+      type: "source_port",
+      pin_label: "pin1",
+    },
+    {
+      type: "schematic_port",
+      display_pin_label: "VBUS",
+    },
+  ])
+})


### PR DESCRIPTION
Fixes #114

/claim #114

## Summary
- accept KiCad symbol libraries alongside footprint input in paste/drop/file flows
- parse `.kicad_sym` pin names, numbers, positions, and rotations
- derive `pinLabels`, `schPortArrangement`, and circuit-json `port_arrangement` metadata
- apply the metadata to both generated TSCircuit JSX and schematic source components

## Verification
- `bun run format:check`
- `bun test`
- `bun run build:lib`
- `bun run build:site`
