### PR TITLE
Add KiCad symbol schematic metadata support

### DIFF
--- a/src/convert-circuit-json-to-tscircuit.ts
+++ b/src/convert-circuit-json-to-tscircuit.ts
@@ -1,0 +1,47 @@
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToTscircuit } from "circuit-json-to-tscircuit"
+import type { KicadSymSchematicMetadata } from "./parse-kicad-sym-to-schematic-metadata"
+
+interface ConvertOptions {
+  componentName: string
+  schematicMetadata?: KicadSymSchematicMetadata
+}
+
+const insertSchPortArrangement = (
+  code: string,
+  schematicMetadata: KicadSymSchematicMetadata,
+) => {
+  const arrangementDecl = `const schPortArrangement = ${JSON.stringify(
+    schematicMetadata.schPortArrangement,
+    null,
+    "  ",
+  )} as const\n`
+
+  const codeWithArrangement = code.replace(
+    /export const /,
+    `${arrangementDecl}export const `,
+  )
+
+  if (codeWithArrangement.includes("schPortArrangement={schPortArrangement}")) {
+    return codeWithArrangement
+  }
+
+  return codeWithArrangement.replace(
+    /\n(\s*)\{\.\.\.props\}/,
+    "\n$1schPortArrangement={schPortArrangement}\n$1{...props}",
+  )
+}
+
+export const convertCircuitJsonToTscircuitWithSchematicMetadata = (
+  circuitJson: AnyCircuitElement[],
+  { componentName, schematicMetadata }: ConvertOptions,
+) => {
+  const code = convertCircuitJsonToTscircuit(circuitJson as any, {
+    componentName,
+    pinLabels: schematicMetadata?.pinLabels,
+  })
+
+  if (!schematicMetadata) return code
+
+  return insertSchPortArrangement(code, schematicMetadata)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
 export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"
+export {
+  applyKicadSymSchematicMetadata,
+  createCircuitJsonFromKicadSymMetadata,
+  parseKicadSymToSchematicMetadata,
+} from "./parse-kicad-sym-to-schematic-metadata"
+export { convertCircuitJsonToTscircuitWithSchematicMetadata } from "./convert-circuit-json-to-tscircuit"

--- a/src/parse-kicad-sym-to-schematic-metadata.ts
+++ b/src/parse-kicad-sym-to-schematic-metadata.ts
@@ -1,0 +1,394 @@
+import type { AnyCircuitElement } from "circuit-json"
+import parseSExpression from "s-expression"
+
+type SExpr = Array<any>
+type PinIdentifier = number | string
+type HorizontalDirection = "top-to-bottom" | "bottom-to-top"
+type VerticalDirection = "left-to-right" | "right-to-left"
+
+export interface KicadSymPin {
+  name?: string
+  number: string
+  identifier: PinIdentifier
+  x: number
+  y: number
+  rotation: number
+  length?: number
+}
+
+export interface KicadSymSchematicMetadata {
+  symbolName: string
+  pins: KicadSymPin[]
+  schPortArrangement: {
+    leftSide?: { pins: PinIdentifier[]; direction: HorizontalDirection }
+    rightSide?: { pins: PinIdentifier[]; direction: HorizontalDirection }
+    topSide?: { pins: PinIdentifier[]; direction: VerticalDirection }
+    bottomSide?: { pins: PinIdentifier[]; direction: VerticalDirection }
+  }
+  portArrangement: {
+    left_side?: { pins: PinIdentifier[]; direction: HorizontalDirection }
+    right_side?: { pins: PinIdentifier[]; direction: HorizontalDirection }
+    top_side?: { pins: PinIdentifier[]; direction: VerticalDirection }
+    bottom_side?: { pins: PinIdentifier[]; direction: VerticalDirection }
+  }
+  pinLabels: Record<string, string>
+  portLabels: Record<string, string>
+}
+
+export interface ParseKicadSymOptions {
+  symbolName?: string
+}
+
+const atomToString = (value: any): string => {
+  if (value === undefined || value === null) return ""
+  return String(value.valueOf())
+}
+
+const isSExpr = (value: any): value is SExpr => Array.isArray(value)
+
+const getToken = (row: any) => (isSExpr(row) ? atomToString(row[0]) : "")
+
+const getChild = (row: SExpr, token: string) =>
+  row.find((child) => getToken(child) === token) as SExpr | undefined
+
+const parseNumber = (value: any, fallback = 0) => {
+  const parsed = Number.parseFloat(atomToString(value))
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+const normalizeRotation = (rotation: number) => ((rotation % 360) + 360) % 360
+
+const pinIdentifierFromNumber = (pinNumber: string): PinIdentifier => {
+  return /^\d+$/.test(pinNumber) ? Number.parseInt(pinNumber, 10) : pinNumber
+}
+
+const pinLabelKey = (identifier: PinIdentifier) => `pin${identifier}`
+
+const normalizePinLabel = (pinName?: string) => {
+  if (!pinName) return undefined
+  const trimmed = pinName.trim()
+  return trimmed && trimmed !== "~" ? trimmed : undefined
+}
+
+const getPinSide = (rotation: number): "left" | "right" | "top" | "bottom" => {
+  const normalized = normalizeRotation(rotation)
+  if (normalized >= 315 || normalized < 45) return "left"
+  if (normalized >= 45 && normalized < 135) return "bottom"
+  if (normalized >= 135 && normalized < 225) return "right"
+  return "top"
+}
+
+const parsePin = (row: SExpr): KicadSymPin | undefined => {
+  const at = getChild(row, "at")
+  const length = getChild(row, "length")
+  const name = getChild(row, "name")
+  const number = getChild(row, "number")
+  const pinNumber = atomToString(number?.[1])
+
+  if (!pinNumber) return undefined
+
+  return {
+    name: normalizePinLabel(atomToString(name?.[1])),
+    number: pinNumber,
+    identifier: pinIdentifierFromNumber(pinNumber),
+    x: parseNumber(at?.[1]),
+    y: parseNumber(at?.[2]),
+    rotation: parseNumber(at?.[3]),
+    length: length ? parseNumber(length[1]) : undefined,
+  }
+}
+
+const collectPins = (row: SExpr): KicadSymPin[] => {
+  const pins: KicadSymPin[] = []
+
+  for (const child of row.slice(2)) {
+    if (!isSExpr(child)) continue
+    const token = getToken(child)
+    if (token === "pin") {
+      const pin = parsePin(child)
+      if (pin) pins.push(pin)
+    } else if (token === "symbol") {
+      pins.push(...collectPins(child))
+    }
+  }
+
+  return pins
+}
+
+const uniquePins = (pins: KicadSymPin[]) => {
+  const seen = new Set<string>()
+  const deduped: KicadSymPin[] = []
+
+  for (const pin of pins) {
+    const key = `${pin.number}:${pin.name ?? ""}:${pin.x}:${pin.y}:${pin.rotation}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    deduped.push(pin)
+  }
+
+  return deduped
+}
+
+const sortSidePins = (pins: KicadSymPin[], side: string) => {
+  return [...pins].sort((a, b) => {
+    if (side === "left" || side === "right") {
+      return b.y - a.y || a.x - b.x
+    }
+    return a.x - b.x || b.y - a.y
+  })
+}
+
+const createMetadata = (symbolName: string, pins: KicadSymPin[]) => {
+  const pinsBySide = {
+    left: [] as KicadSymPin[],
+    right: [] as KicadSymPin[],
+    top: [] as KicadSymPin[],
+    bottom: [] as KicadSymPin[],
+  }
+
+  for (const pin of pins) {
+    pinsBySide[getPinSide(pin.rotation)].push(pin)
+  }
+
+  const leftPins = sortSidePins(pinsBySide.left, "left").map(
+    (pin) => pin.identifier,
+  )
+  const rightPins = sortSidePins(pinsBySide.right, "right").map(
+    (pin) => pin.identifier,
+  )
+  const topPins = sortSidePins(pinsBySide.top, "top").map(
+    (pin) => pin.identifier,
+  )
+  const bottomPins = sortSidePins(pinsBySide.bottom, "bottom").map(
+    (pin) => pin.identifier,
+  )
+
+  const pinLabels: Record<string, string> = {}
+  for (const pin of pins) {
+    if (pin.name) pinLabels[pinLabelKey(pin.identifier)] = pin.name
+  }
+
+  return {
+    symbolName,
+    pins,
+    schPortArrangement: {
+      ...(leftPins.length
+        ? { leftSide: { pins: leftPins, direction: "top-to-bottom" as const } }
+        : {}),
+      ...(rightPins.length
+        ? {
+            rightSide: { pins: rightPins, direction: "top-to-bottom" as const },
+          }
+        : {}),
+      ...(topPins.length
+        ? { topSide: { pins: topPins, direction: "left-to-right" as const } }
+        : {}),
+      ...(bottomPins.length
+        ? {
+            bottomSide: {
+              pins: bottomPins,
+              direction: "left-to-right" as const,
+            },
+          }
+        : {}),
+    },
+    portArrangement: {
+      ...(leftPins.length
+        ? { left_side: { pins: leftPins, direction: "top-to-bottom" as const } }
+        : {}),
+      ...(rightPins.length
+        ? {
+            right_side: {
+              pins: rightPins,
+              direction: "top-to-bottom" as const,
+            },
+          }
+        : {}),
+      ...(topPins.length
+        ? { top_side: { pins: topPins, direction: "left-to-right" as const } }
+        : {}),
+      ...(bottomPins.length
+        ? {
+            bottom_side: {
+              pins: bottomPins,
+              direction: "left-to-right" as const,
+            },
+          }
+        : {}),
+    },
+    pinLabels,
+    portLabels: pinLabels,
+  } satisfies KicadSymSchematicMetadata
+}
+
+const getTopLevelSymbols = (root: SExpr) => {
+  if (getToken(root) === "symbol") return [root]
+  if (getToken(root) !== "kicad_symbol_lib") return []
+  return root.filter((child) => getToken(child) === "symbol") as SExpr[]
+}
+
+export const parseKicadSymToSchematicMetadata = (
+  kicadSym: string,
+  options: ParseKicadSymOptions = {},
+): KicadSymSchematicMetadata[] => {
+  const root = parseSExpression(kicadSym) as SExpr
+  const symbols = getTopLevelSymbols(root)
+  const results: KicadSymSchematicMetadata[] = []
+
+  for (const symbol of symbols) {
+    const symbolName = atomToString(symbol[1])
+    if (options.symbolName && symbolName !== options.symbolName) continue
+
+    const pins = uniquePins(collectPins(symbol))
+    if (pins.length === 0) continue
+
+    results.push(createMetadata(symbolName, pins))
+  }
+
+  return results
+}
+
+export const createCircuitJsonFromKicadSymMetadata = (
+  metadata: KicadSymSchematicMetadata,
+): AnyCircuitElement[] => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: metadata.symbolName,
+      ftype: "simple_chip",
+    } as any,
+    {
+      type: "schematic_component",
+      schematic_component_id: "schematic_component_0",
+      source_component_id: "source_component_0",
+      center: { x: 0, y: 0 },
+      rotation: 0,
+      size: { width: 2, height: Math.max(1, metadata.pins.length * 0.2) },
+      is_box_with_pins: true,
+      port_arrangement: metadata.portArrangement,
+      port_labels: metadata.portLabels,
+    } as any,
+  ]
+
+  for (const [index, pin] of metadata.pins.entries()) {
+    const sourcePortId = `source_port_${index}`
+    const schematicPortId = `schematic_port_${index}`
+    const displayPinLabel = pin.name ?? pin.number
+
+    circuitJson.push({
+      type: "source_port",
+      source_port_id: sourcePortId,
+      source_component_id: "source_component_0",
+      name: pin.number,
+      port_hints: [pin.number, displayPinLabel],
+      pin_number:
+        typeof pin.identifier === "number" ? pin.identifier : undefined,
+      pin_label: pinLabelKey(pin.identifier),
+    } as any)
+    circuitJson.push({
+      type: "schematic_port",
+      schematic_port_id: schematicPortId,
+      source_port_id: sourcePortId,
+      schematic_component_id: "schematic_component_0",
+      center: { x: 0, y: 0 },
+      pin_number:
+        typeof pin.identifier === "number" ? pin.identifier : undefined,
+      display_pin_label: displayPinLabel,
+      side_of_component: getPinSide(pin.rotation),
+    } as any)
+  }
+
+  return circuitJson
+}
+
+export const applyKicadSymSchematicMetadata = (
+  circuitJson: AnyCircuitElement[],
+  metadata: KicadSymSchematicMetadata,
+): AnyCircuitElement[] => {
+  const findMatchingPin = (element: any) => {
+    const elementPinNumber =
+      typeof element.pin_number === "number" ? element.pin_number : undefined
+    const elementNames = [
+      element.name,
+      element.pin_label,
+      ...(Array.isArray(element.port_hints) ? element.port_hints : []),
+    ].map((value) => atomToString(value))
+
+    return metadata.pins.find((pin) => {
+      if (
+        typeof pin.identifier === "number" &&
+        pin.identifier === elementPinNumber
+      ) {
+        return true
+      }
+      return (
+        elementNames.includes(pin.number) ||
+        elementNames.includes(pin.name ?? "")
+      )
+    })
+  }
+
+  const sourcePortPinById = new Map<string, KicadSymPin>()
+  for (const element of circuitJson as any[]) {
+    if (element.type !== "source_port") continue
+    const matchingPin = findMatchingPin(element)
+    if (matchingPin) sourcePortPinById.set(element.source_port_id, matchingPin)
+  }
+
+  return circuitJson.map((element: any) => {
+    if (element.type === "schematic_component") {
+      return {
+        ...element,
+        size:
+          element.size?.width && element.size?.height
+            ? element.size
+            : { width: 2, height: Math.max(1, metadata.pins.length * 0.2) },
+        is_box_with_pins: true,
+        port_arrangement: metadata.portArrangement,
+        port_labels: metadata.portLabels,
+      }
+    }
+
+    if (element.type !== "source_port" && element.type !== "schematic_port") {
+      return element
+    }
+
+    const matchingPin =
+      element.type === "schematic_port"
+        ? (sourcePortPinById.get(element.source_port_id) ??
+          findMatchingPin(element))
+        : findMatchingPin(element)
+
+    if (!matchingPin) return element
+
+    const displayPinLabel = matchingPin.name ?? matchingPin.number
+    if (element.type === "source_port") {
+      return {
+        ...element,
+        port_hints: Array.from(
+          new Set([
+            ...(element.port_hints ?? []),
+            matchingPin.number,
+            displayPinLabel,
+          ]),
+        ),
+        pin_number:
+          typeof matchingPin.identifier === "number"
+            ? matchingPin.identifier
+            : element.pin_number,
+        pin_label: pinLabelKey(matchingPin.identifier),
+      }
+    }
+
+    return {
+      ...element,
+      pin_number:
+        typeof matchingPin.identifier === "number"
+          ? matchingPin.identifier
+          : element.pin_number,
+      display_pin_label: displayPinLabel,
+      side_of_component: getPinSide(matchingPin.rotation),
+    }
+  })
+}

--- a/src/site/App.tsx
+++ b/src/site/App.tsx
@@ -2,8 +2,13 @@ import { useCallback, useState, useRef } from "react"
 import { useStore } from "./use-store"
 import { Download, FileSearch } from "lucide-react"
 import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import {
+  applyKicadSymSchematicMetadata,
+  createCircuitJsonFromKicadSymMetadata,
+  parseKicadSymToSchematicMetadata,
+} from "src/parse-kicad-sym-to-schematic-metadata"
 import { CircuitJsonPreview } from "@tscircuit/runframe"
-import { convertCircuitJsonToTscircuit } from "circuit-json-to-tscircuit"
+import { convertCircuitJsonToTscircuitWithSchematicMetadata } from "src/convert-circuit-json-to-tscircuit"
 import { createSnippetUrl } from "@tscircuit/create-snippet-url"
 
 export const App = () => {
@@ -19,29 +24,46 @@ export const App = () => {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const handleProcessAndViewFiles = useCallback(async () => {
-    if (!filesAdded.kicad_mod) {
-      setError("No KiCad Mod file added")
+    if (!filesAdded.kicad_mod && !filesAdded.kicad_sym) {
+      setError("No KiCad file added")
       return
     }
     setError(null)
-    let circuitJson: any
-    try {
-      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
-      updateCircuitJson(circuitJson as any)
-    } catch (err: any) {
-      setError(`Error parsing KiCad Mod file: ${err.toString()}`)
-      return
-    }
 
     try {
-      // Now we convert the circuit json to tscircuit
-      const tscircuit = convertCircuitJsonToTscircuit(circuitJson, {
-        componentName: "MyComponent",
-      })
+      const schematicMetadata = filesAdded.kicad_sym
+        ? parseKicadSymToSchematicMetadata(filesAdded.kicad_sym)[0]
+        : undefined
+
+      if (filesAdded.kicad_sym && !schematicMetadata) {
+        setError("No pins found in KiCad Symbol file")
+        return
+      }
+
+      let circuitJson = filesAdded.kicad_mod
+        ? await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+        : createCircuitJsonFromKicadSymMetadata(schematicMetadata!)
+
+      if (schematicMetadata) {
+        circuitJson = applyKicadSymSchematicMetadata(
+          circuitJson,
+          schematicMetadata,
+        )
+      }
+
+      updateCircuitJson(circuitJson as any)
+
+      const tscircuit = convertCircuitJsonToTscircuitWithSchematicMetadata(
+        circuitJson,
+        {
+          componentName: "MyComponent",
+          schematicMetadata,
+        },
+      )
       updateTscircuitCode(tscircuit)
     } catch (err: any) {
       setError(
-        `Error converting circuit json to tscircuit: ${err.toString()}\n\n${err.stack}`,
+        `Error processing KiCad file: ${err.toString()}\n\n${err.stack ?? ""}`,
       )
     }
   }, [filesAdded])
@@ -55,7 +77,11 @@ export const App = () => {
         file.trim().startsWith("(footprint")
       ) {
         addFile("kicad_mod", file)
-      } else if (fileName.endsWith(".kicad_sym")) {
+      } else if (
+        fileName.endsWith(".kicad_sym") ||
+        file.trim().startsWith("(kicad_symbol_lib") ||
+        file.trim().startsWith("(symbol")
+      ) {
         addFile("kicad_sym", file)
       } else {
         setError("Unsupported file type")
@@ -84,7 +110,10 @@ export const App = () => {
       if (!content) return
       if (content.trim().startsWith("(footprint")) {
         addDroppedFile("kicad_mod", content)
-      } else if (content.trim().startsWith("(symbol")) {
+      } else if (
+        content.trim().startsWith("(kicad_symbol_lib") ||
+        content.trim().startsWith("(symbol")
+      ) {
         addDroppedFile("kicad_sym", content)
       } else {
         setError("Unsupported file type (file an issue if we're wrong)")
@@ -148,9 +177,21 @@ export const App = () => {
                   filesAdded.kicad_mod ? "text-green-500" : "text-red-500"
                 }
               >
-                {filesAdded.kicad_mod ? "✅" : "❌"}
+                {filesAdded.kicad_mod ? "+" : "-"}
               </span>
-              <span className="text-gray-300">KiCad Mod File</span>
+              <span className="text-gray-300">
+                KiCad Footprint (.kicad_mod)
+              </span>
+            </div>
+            <div className="flex items-center gap-2 bg-gray-800/50 p-3 rounded-md">
+              <span
+                className={
+                  filesAdded.kicad_sym ? "text-green-500" : "text-gray-500"
+                }
+              >
+                {filesAdded.kicad_sym ? "+" : "-"}
+              </span>
+              <span className="text-gray-300">KiCad Symbol (.kicad_sym)</span>
             </div>
           </div>
           <div className="flex justify-center items-center gap-2">
@@ -207,9 +248,12 @@ export const App = () => {
                   try {
                     const code =
                       tscircuitCode ??
-                      convertCircuitJsonToTscircuit(circuitJson, {
-                        componentName: "MyComponent",
-                      })
+                      convertCircuitJsonToTscircuitWithSchematicMetadata(
+                        circuitJson,
+                        {
+                          componentName: "MyComponent",
+                        },
+                      )
                     const blob = new Blob([code], { type: "text/tsx" })
                     const url = URL.createObjectURL(blob)
                     const a = document.createElement("a")

--- a/tests/kicad-sym-schematic-metadata.test.ts
+++ b/tests/kicad-sym-schematic-metadata.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "bun:test"
+import {
+  applyKicadSymSchematicMetadata,
+  convertCircuitJsonToTscircuitWithSchematicMetadata,
+  createCircuitJsonFromKicadSymMetadata,
+  parseKicadModToCircuitJson,
+  parseKicadSymToSchematicMetadata,
+} from "src"
+import fs from "node:fs"
+import { join } from "node:path"
+
+const simpleKicadSym = `(kicad_symbol_lib
+  (version 20230121)
+  (generator kicad_symbol_editor)
+  (symbol "Device:MiniChip"
+    (symbol "Device:MiniChip_0_1"
+      (pin power_in line (at -5.08 1.27 0) (length 2.54)
+        (name "VCC" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27)))))
+      (pin power_in line (at -5.08 -1.27 0) (length 2.54)
+        (name "GND" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27)))))
+      (pin output line (at 5.08 0 180) (length 2.54)
+        (name "OUT" (effects (font (size 1.27 1.27))))
+        (number "3" (effects (font (size 1.27 1.27)))))
+    )
+  )
+)`
+
+test("parses KiCad symbol pins into schematic arrangement and pin labels", () => {
+  const [metadata] = parseKicadSymToSchematicMetadata(simpleKicadSym)
+
+  expect(metadata.symbolName).toBe("Device:MiniChip")
+  expect(metadata.schPortArrangement).toEqual({
+    leftSide: { pins: [1, 2], direction: "top-to-bottom" },
+    rightSide: { pins: [3], direction: "top-to-bottom" },
+  })
+  expect(metadata.portArrangement).toEqual({
+    left_side: { pins: [1, 2], direction: "top-to-bottom" },
+    right_side: { pins: [3], direction: "top-to-bottom" },
+  })
+  expect(metadata.pinLabels).toEqual({
+    pin1: "VCC",
+    pin2: "GND",
+    pin3: "OUT",
+  })
+})
+
+test("creates symbol-only circuit json and tscircuit code from kicad_sym", () => {
+  const [metadata] = parseKicadSymToSchematicMetadata(simpleKicadSym)
+  const circuitJson = createCircuitJsonFromKicadSymMetadata(metadata)
+  const schematicComponent = circuitJson.find(
+    (element: any) => element.type === "schematic_component",
+  ) as any
+
+  expect(schematicComponent.port_arrangement).toEqual(metadata.portArrangement)
+  expect(schematicComponent.port_labels).toEqual(metadata.portLabels)
+
+  const tscircuitCode = convertCircuitJsonToTscircuitWithSchematicMetadata(
+    circuitJson,
+    { componentName: "MyComponent", schematicMetadata: metadata },
+  )
+
+  expect(tscircuitCode).toContain("const pinLabels =")
+  expect(tscircuitCode).toContain("const schPortArrangement =")
+  expect(tscircuitCode).toContain("pinLabels={pinLabels}")
+  expect(tscircuitCode).toContain("schPortArrangement={schPortArrangement}")
+})
+
+test("applies kicad_sym schematic metadata to a parsed kicad_mod footprint", async () => {
+  const footprint = fs.readFileSync(
+    join(
+      import.meta.dirname,
+      "fixtures/kicad-footprints/Connector_JST.pretty/JST_PH_B2B-PH-K_1x02_P2.00mm_Vertical.kicad_mod",
+    ),
+    "utf8",
+  )
+  const [metadata] = parseKicadSymToSchematicMetadata(simpleKicadSym)
+  const circuitJson = applyKicadSymSchematicMetadata(
+    await parseKicadModToCircuitJson(footprint),
+    metadata,
+  )
+  const schematicComponent = circuitJson.find(
+    (element: any) => element.type === "schematic_component",
+  ) as any
+  const schematicPorts = circuitJson.filter(
+    (element: any) => element.type === "schematic_port",
+  ) as any[]
+
+  expect(schematicComponent.port_arrangement).toEqual(metadata.portArrangement)
+  expect(schematicComponent.port_labels).toEqual(metadata.portLabels)
+  expect(schematicPorts.find((port) => port.pin_number === 1)).toMatchObject({
+    display_pin_label: "VCC",
+    side_of_component: "left",
+  })
+  expect(schematicPorts.find((port) => port.pin_number === 2)).toMatchObject({
+    display_pin_label: "GND",
+    side_of_component: "left",
+  })
+})


### PR DESCRIPTION
## Summary

/claim #114

Fixes tscircuit/kicad-component-converter#114 by adding `.kicad_sym` support for schematic metadata:

- parses KiCad symbol pins into schematic port arrangement and pin labels
- applies symbol metadata to parsed `.kicad_mod` circuit JSON when both files are provided
- supports symbol-only previews by creating source/schematic ports from `.kicad_sym`
- generates tscircuit code with both `pinLabels` and `schPortArrangement`
- updates the web viewer to accept `.kicad_sym` files by extension or pasted `(kicad_symbol_lib ...)` / `(symbol ...)` content

This contribution was prepared with AI assistance and reviewed/tested locally before submission.

## Verification

- `bun test`
- `bun run format:check`
- `bun run build`
- `bun run build:site`

## Notes

I noticed an older `kicad-sym-to-cj` branch in the repo, but it had stale dependency changes and broad snapshot churn. This patch keeps the implementation focused on the current `main` branch and avoids dependency changes.
