### PR TITLE
feat: derive schematic metadata from kicad_sym

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
 export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"
+export { parseKicadSymToSchematicMetadata } from "./parse-kicad-sym-to-schematic-metadata"

--- a/src/parse-kicad-mod-to-circuit-json.ts
+++ b/src/parse-kicad-mod-to-circuit-json.ts
@@ -1,12 +1,25 @@
 import type { AnyCircuitElement } from "circuit-json"
 import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 import { convertKicadJsonToTsCircuitSoup as convertKicadJsonToCircuitJson } from "./convert-kicad-json-to-tscircuit-soup"
+import { parseKicadSymToSchematicMetadata } from "./parse-kicad-sym-to-schematic-metadata"
 
 export const parseKicadModToCircuitJson = async (
   kicadMod: string,
+  options?: {
+    kicadSym?: string
+  },
 ): Promise<AnyCircuitElement[]> => {
   const kicadJson = parseKicadModToKicadJson(kicadMod)
 
   const circuitJson = await convertKicadJsonToCircuitJson(kicadJson)
+  if (options?.kicadSym) {
+    const schematicMetadata = parseKicadSymToSchematicMetadata(options.kicadSym)
+    const sourceComponent = circuitJson.find(
+      (element) => element.type === "source_component",
+    )
+    if (sourceComponent) {
+      Object.assign(sourceComponent, schematicMetadata)
+    }
+  }
   return circuitJson as any
 }

--- a/src/parse-kicad-sym-to-schematic-metadata.ts
+++ b/src/parse-kicad-sym-to-schematic-metadata.ts
@@ -1,0 +1,123 @@
+import parseSExpression from "s-expression"
+import { getAttr } from "./get-attr"
+
+type PinSide = "leftSide" | "rightSide" | "topSide" | "bottomSide"
+
+export interface KicadSymSchematicMetadata {
+  pinLabels: Record<string, string>
+  schPortArrangement: Partial<
+    Record<
+      PinSide,
+      {
+        pins: string[]
+        direction:
+          | "top-to-bottom"
+          | "left-to-right"
+          | "bottom-to-top"
+          | "right-to-left"
+      }
+    >
+  >
+}
+
+interface KicadSymPin {
+  pinKey: string
+  label: string
+  at: number[]
+  side: PinSide
+}
+
+const toPrimitive = (value: any) => value?.valueOf?.() ?? value
+
+const getNodeName = (node: any) =>
+  Array.isArray(node) ? toPrimitive(node[0]) : undefined
+
+const walkSExpr = (node: any, visit: (node: any[]) => void) => {
+  if (!Array.isArray(node)) return
+  visit(node)
+  for (const child of node) {
+    walkSExpr(child, visit)
+  }
+}
+
+const getPinText = (pinNode: any[], key: "name" | "number") => {
+  const textNode = pinNode.find((child) => getNodeName(child) === key)
+  const text = Array.isArray(textNode) ? toPrimitive(textNode[1]) : undefined
+  return typeof text === "string" ? text : undefined
+}
+
+const getPinSide = (rotation: number): PinSide => {
+  const normalized = ((rotation % 360) + 360) % 360
+  if (normalized === 180) return "rightSide"
+  if (normalized === 90) return "bottomSide"
+  if (normalized === 270) return "topSide"
+  return "leftSide"
+}
+
+const sortPinsForSide = (side: PinSide, pins: KicadSymPin[]) => {
+  return [...pins].sort((a, b) => {
+    if (side === "leftSide" || side === "rightSide") {
+      return b.at[1] - a.at[1] || a.at[0] - b.at[0]
+    }
+    return a.at[0] - b.at[0] || b.at[1] - a.at[1]
+  })
+}
+
+export const parseKicadSymToSchematicMetadata = (
+  fileContent: string,
+): KicadSymSchematicMetadata => {
+  const kicadSExpr = parseSExpression(fileContent)
+  const pins: KicadSymPin[] = []
+
+  walkSExpr(kicadSExpr, (node) => {
+    if (getNodeName(node) !== "pin") return
+
+    const pinNumber = getPinText(node, "number")
+    if (!pinNumber) return
+
+    const pinName = getPinText(node, "name")
+    const at = getAttr(node, "at")
+    if (!Array.isArray(at) || at.length < 2) return
+
+    const rotation = at[2] ?? 0
+    const pinKey = `pin${pinNumber}`
+    pins.push({
+      pinKey,
+      label: pinName && pinName !== "~" ? pinName : pinKey,
+      at,
+      side: getPinSide(rotation),
+    })
+  })
+
+  const pinLabels: Record<string, string> = {}
+  const pinsBySide = new Map<PinSide, KicadSymPin[]>()
+  for (const pin of pins) {
+    pinLabels[pin.pinKey] = pin.label
+    pinsBySide.set(pin.side, [...(pinsBySide.get(pin.side) ?? []), pin])
+  }
+
+  const schPortArrangement: KicadSymSchematicMetadata["schPortArrangement"] = {}
+  const sideDirections = {
+    leftSide: "top-to-bottom",
+    rightSide: "top-to-bottom",
+    topSide: "left-to-right",
+    bottomSide: "left-to-right",
+  } as const
+
+  for (const side of [
+    "leftSide",
+    "rightSide",
+    "topSide",
+    "bottomSide",
+  ] as const) {
+    const sidePins = pinsBySide.get(side)
+    if (!sidePins?.length) continue
+
+    schPortArrangement[side] = {
+      pins: sortPinsForSide(side, sidePins).map((pin) => pin.pinKey),
+      direction: sideDirections[side],
+    }
+  }
+
+  return { pinLabels, schPortArrangement }
+}

--- a/tests/kicad-sym-schematic-metadata.test.ts
+++ b/tests/kicad-sym-schematic-metadata.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "bun:test"
+import {
+  parseKicadModToCircuitJson,
+  parseKicadSymToSchematicMetadata,
+} from "src"
+
+const kicadSym = `
+(kicad_symbol_lib
+  (version 20231120)
+  (generator "kicad_symbol_editor")
+  (symbol "Test:Four_Pin"
+    (symbol "Four_Pin_0_1"
+      (pin input line (at -5.08 2.54 0) (length 2.54)
+        (name "VCC" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27)))))
+      (pin input line (at -5.08 -2.54 0) (length 2.54)
+        (name "GND" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27)))))
+      (pin output line (at 5.08 2.54 180) (length 2.54)
+        (name "SDA" (effects (font (size 1.27 1.27))))
+        (number "3" (effects (font (size 1.27 1.27)))))
+      (pin output line (at 5.08 -2.54 180) (length 2.54)
+        (name "SCL" (effects (font (size 1.27 1.27))))
+        (number "4" (effects (font (size 1.27 1.27)))))
+    )
+  )
+)
+`
+
+const kicadMod = `
+(footprint "Four_Pin"
+  (version 20240108)
+  (generator "pcbnew")
+  (layer "F.Cu")
+  (property "Reference" "U" (at 0 0 0) (layer "F.SilkS"))
+  (property "Value" "Four_Pin" (at 0 0 0) (layer "F.Fab"))
+  (pad "1" smd rect (at -1.5 1.5 0) (size 1 1) (layers "F.Cu"))
+  (pad "2" smd rect (at -1.5 -1.5 0) (size 1 1) (layers "F.Cu"))
+  (pad "3" smd rect (at 1.5 1.5 0) (size 1 1) (layers "F.Cu"))
+  (pad "4" smd rect (at 1.5 -1.5 0) (size 1 1) (layers "F.Cu"))
+)
+`
+
+test("parseKicadSymToSchematicMetadata converts symbol pins into labels and side arrangement", () => {
+  expect(parseKicadSymToSchematicMetadata(kicadSym)).toEqual({
+    pinLabels: {
+      pin1: "VCC",
+      pin2: "GND",
+      pin3: "SDA",
+      pin4: "SCL",
+    },
+    schPortArrangement: {
+      leftSide: {
+        pins: ["pin1", "pin2"],
+        direction: "top-to-bottom",
+      },
+      rightSide: {
+        pins: ["pin3", "pin4"],
+        direction: "top-to-bottom",
+      },
+    },
+  })
+})
+
+test("parseKicadModToCircuitJson accepts kicadSym metadata", async () => {
+  const circuitJson = await parseKicadModToCircuitJson(kicadMod, { kicadSym })
+  const sourceComponent = circuitJson.find(
+    (element) => element.type === "source_component",
+  ) as any
+
+  expect(sourceComponent.pinLabels).toEqual({
+    pin1: "VCC",
+    pin2: "GND",
+    pin3: "SDA",
+    pin4: "SCL",
+  })
+  expect(sourceComponent.schPortArrangement.leftSide.pins).toEqual([
+    "pin1",
+    "pin2",
+  ])
+  expect(sourceComponent.schPortArrangement.rightSide.pins).toEqual([
+    "pin3",
+    "pin4",
+  ])
+})


### PR DESCRIPTION
Fixes #114

Adds optional `.kicad_sym` parsing support to derive:
- `pinLabels`
- `schPortArrangement`

Also adds tests covering direct symbol parsing and `.kicad_mod` conversion with symbol metadata.

Tested:
- `bun test`
- `bunx tsc --noEmit`
- `bun run build:lib`