### PR TITLE
feat: add kicad_sym parser for schematic pin labels and port arrangement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
 export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"
+export { parseKicadSymToSchematicMetadata } from "./parse-kicad-sym-to-schematic-metadata"
+export type {
+  KicadSymSchematicMetadata,
+  PinSide,
+  SchPortSide,
+} from "./parse-kicad-sym-to-schematic-metadata"

--- a/src/parse-kicad-mod-to-circuit-json.ts
+++ b/src/parse-kicad-mod-to-circuit-json.ts
@@ -1,12 +1,24 @@
 import type { AnyCircuitElement } from "circuit-json"
-import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 import { convertKicadJsonToTsCircuitSoup as convertKicadJsonToCircuitJson } from "./convert-kicad-json-to-tscircuit-soup"
+import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
+import { parseKicadSymToSchematicMetadata } from "./parse-kicad-sym-to-schematic-metadata"
 
 export const parseKicadModToCircuitJson = async (
   kicadMod: string,
+  options?: { kicadSym?: string },
 ): Promise<AnyCircuitElement[]> => {
   const kicadJson = parseKicadModToKicadJson(kicadMod)
-
   const circuitJson = await convertKicadJsonToCircuitJson(kicadJson)
+
+  if (options?.kicadSym) {
+    const meta = parseKicadSymToSchematicMetadata(options.kicadSym)
+    const sourceComponent = circuitJson.find(
+      (el) => el.type === "source_component",
+    )
+    if (sourceComponent) {
+      Object.assign(sourceComponent, meta)
+    }
+  }
+
   return circuitJson as any
 }

--- a/src/parse-kicad-sym-to-schematic-metadata.ts
+++ b/src/parse-kicad-sym-to-schematic-metadata.ts
@@ -1,0 +1,158 @@
+import parseSExpression from "s-expression"
+
+export type PinSide = "leftSide" | "rightSide" | "topSide" | "bottomSide"
+
+export interface SchPortSide {
+  pins: string[]
+  direction:
+    | "top-to-bottom"
+    | "left-to-right"
+    | "bottom-to-top"
+    | "right-to-left"
+}
+
+export interface KicadSymSchematicMetadata {
+  pinLabels: Record<string, string>
+  schPortArrangement: Partial<Record<PinSide, SchPortSide>>
+}
+
+interface ParsedPin {
+  pinKey: string
+  name: string
+  x: number
+  y: number
+  side: PinSide
+}
+
+/** KiCad pin rotation → which side of the symbol the pin connects to */
+function rotationToSide(rotation: number): PinSide {
+  const normalized = ((Math.round(rotation) % 360) + 360) % 360
+  if (normalized === 180) return "rightSide"
+  if (normalized === 90) return "bottomSide"
+  if (normalized === 270) return "topSide"
+  return "leftSide" // 0° default
+}
+
+function nodeTag(node: any): string | undefined {
+  if (!Array.isArray(node) || node.length === 0) return undefined
+  const first = node[0]
+  if (typeof first === "string") return first
+  if (first && typeof first.valueOf === "function") {
+    const v = first.valueOf()
+    return typeof v === "string" ? v : undefined
+  }
+  return undefined
+}
+
+function findChildren(node: any[], tag: string): any[][] {
+  return node.slice(1).filter((child) => nodeTag(child) === tag) as any[][]
+}
+
+function stringVal(node: any): string {
+  if (typeof node === "string") return node
+  if (node && typeof node.valueOf === "function") return String(node.valueOf())
+  return String(node)
+}
+
+function numVal(node: any): number {
+  return Number.parseFloat(stringVal(node))
+}
+
+/** Extract all pins from a parsed kicad_sym S-expression node (recursively). */
+function extractPins(node: any, acc: ParsedPin[] = []): ParsedPin[] {
+  if (!Array.isArray(node)) return acc
+  const tag = nodeTag(node)
+
+  if (tag === "pin") {
+    // Skip no_connect / invisible pins
+    const isHidden = node.some(
+      (child) =>
+        (typeof child === "string" && child === "hide") ||
+        (child &&
+          typeof child.valueOf === "function" &&
+          child.valueOf() === "hide"),
+    )
+    const pinType = node.length > 1 ? stringVal(node[1]) : ""
+    if (!isHidden && pinType !== "no_connect") {
+      // (at x y rotation)
+      const atNode = findChildren(node, "at")[0]
+      const x = atNode ? numVal(atNode[1]) : 0
+      const y = atNode ? numVal(atNode[2]) : 0
+      const rotation = atNode && atNode.length >= 4 ? numVal(atNode[3]) : 0
+
+      // (number "N" ...)
+      const numberNode = findChildren(node, "number")[0]
+      const pinNumber = numberNode ? stringVal(numberNode[1]) : "?"
+
+      // (name "Label" ...)
+      const nameNode = findChildren(node, "name")[0]
+      const pinName = nameNode ? stringVal(nameNode[1]) : pinNumber
+
+      acc.push({
+        pinKey: `pin${pinNumber}`,
+        name: pinName,
+        x,
+        y,
+        side: rotationToSide(rotation),
+      })
+    }
+    return acc
+  }
+
+  // Recurse into children (skip deep nesting inside a pin node — already handled above)
+  for (const child of node.slice(1)) {
+    extractPins(child, acc)
+  }
+  return acc
+}
+
+const SIDE_DIRECTIONS: Record<PinSide, SchPortSide["direction"]> = {
+  leftSide: "top-to-bottom",
+  rightSide: "top-to-bottom",
+  topSide: "left-to-right",
+  bottomSide: "left-to-right",
+}
+
+function sortPins(side: PinSide, pins: ParsedPin[]): ParsedPin[] {
+  if (side === "leftSide" || side === "rightSide") {
+    // KiCad Y increases downward; schematic Y typically increases downward too
+    // Sort ascending by Y so higher pins appear first (top-to-bottom)
+    return [...pins].sort((a, b) => b.y - a.y)
+  }
+  // topSide / bottomSide: sort left-to-right by X
+  return [...pins].sort((a, b) => a.x - b.x)
+}
+
+/**
+ * Parse a `.kicad_sym` file and produce schematic metadata including
+ * `pinLabels` and `schPortArrangement`.
+ */
+export function parseKicadSymToSchematicMetadata(
+  kicadSym: string,
+): KicadSymSchematicMetadata {
+  const parsed = parseSExpression(kicadSym)
+  const pins = extractPins(parsed)
+
+  const pinLabels: Record<string, string> = {}
+  const bySide: Partial<Record<PinSide, ParsedPin[]>> = {}
+
+  for (const pin of pins) {
+    pinLabels[pin.pinKey] = pin.name
+    bySide[pin.side] ??= []
+    bySide[pin.side]!.push(pin)
+  }
+
+  const schPortArrangement: Partial<Record<PinSide, SchPortSide>> = {}
+  for (const [side, sidePins] of Object.entries(bySide) as [
+    PinSide,
+    ParsedPin[],
+  ][]) {
+    const sorted = sortPins(side, sidePins)
+    schPortArrangement[side] = {
+      pins: sorted.map((p) => p.pinKey),
+      direction: SIDE_DIRECTIONS[side],
+    }
+  }
+
+  return { pinLabels, schPortArrangement }
+}

--- a/src/site/App.tsx
+++ b/src/site/App.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useState, useRef } from "react"
-import { useStore } from "./use-store"
-import { Download, FileSearch } from "lucide-react"
-import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import { createSnippetUrl } from "@tscircuit/create-snippet-url"
 import { CircuitJsonPreview } from "@tscircuit/runframe"
 import { convertCircuitJsonToTscircuit } from "circuit-json-to-tscircuit"
-import { createSnippetUrl } from "@tscircuit/create-snippet-url"
+import { Download, FileSearch } from "lucide-react"
+import { useCallback, useRef, useState } from "react"
+import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import { useStore } from "./use-store"
 
 export const App = () => {
   const [error, setError] = useState<string | null>(null)
@@ -20,13 +20,15 @@ export const App = () => {
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const handleProcessAndViewFiles = useCallback(async () => {
     if (!filesAdded.kicad_mod) {
-      setError("No KiCad Mod file added")
+      setError("No KiCad Mod file (.kicad_mod) added")
       return
     }
     setError(null)
     let circuitJson: any
     try {
-      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod, {
+        kicadSym: filesAdded.kicad_sym,
+      })
       updateCircuitJson(circuitJson as any)
     } catch (err: any) {
       setError(`Error parsing KiCad Mod file: ${err.toString()}`)
@@ -150,7 +152,26 @@ export const App = () => {
               >
                 {filesAdded.kicad_mod ? "✅" : "❌"}
               </span>
-              <span className="text-gray-300">KiCad Mod File</span>
+              <span className="text-gray-300">
+                KiCad Mod File{" "}
+                <span className="text-gray-500 text-xs">(.kicad_mod)</span>
+              </span>
+            </div>
+            <div className="flex items-center gap-2 bg-gray-800/50 p-3 rounded-md">
+              <span
+                className={
+                  filesAdded.kicad_sym ? "text-green-500" : "text-gray-500"
+                }
+              >
+                {filesAdded.kicad_sym ? "✅" : "➖"}
+              </span>
+              <span className="text-gray-300">
+                KiCad Symbol File{" "}
+                <span className="text-gray-500 text-xs">
+                  (.kicad_sym, optional — adds pin labels &amp; schematic
+                  arrangement)
+                </span>
+              </span>
             </div>
           </div>
           <div className="flex justify-center items-center gap-2">

--- a/tests/parse-kicad-sym.test.ts
+++ b/tests/parse-kicad-sym.test.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "bun:test"
+import {
+  parseKicadModToCircuitJson,
+  parseKicadSymToSchematicMetadata,
+} from "src"
+
+const FOUR_PIN_SYM = `
+(kicad_symbol_lib
+  (version 20231120)
+  (generator "kicad_symbol_editor")
+  (symbol "Test:FourPin"
+    (symbol "FourPin_0_1"
+      (pin input line (at -5.08 2.54 0) (length 2.54)
+        (name "VCC" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27)))))
+      (pin input line (at -5.08 -2.54 0) (length 2.54)
+        (name "GND" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27)))))
+      (pin output line (at 5.08 2.54 180) (length 2.54)
+        (name "SDA" (effects (font (size 1.27 1.27))))
+        (number "3" (effects (font (size 1.27 1.27)))))
+      (pin output line (at 5.08 -2.54 180) (length 2.54)
+        (name "SCL" (effects (font (size 1.27 1.27))))
+        (number "4" (effects (font (size 1.27 1.27)))))
+    )
+  )
+)
+`
+
+const FOUR_PIN_MOD = `
+(footprint "FourPin"
+  (version 20240108)
+  (generator "pcbnew")
+  (layer "F.Cu")
+  (property "Reference" "U" (at 0 0 0) (layer "F.SilkS"))
+  (property "Value" "FourPin" (at 0 0 0) (layer "F.Fab"))
+  (pad "1" smd rect (at -1.5 1.5 0) (size 1 1) (layers "F.Cu"))
+  (pad "2" smd rect (at -1.5 -1.5 0) (size 1 1) (layers "F.Cu"))
+  (pad "3" smd rect (at 1.5 1.5 0) (size 1 1) (layers "F.Cu"))
+  (pad "4" smd rect (at 1.5 -1.5 0) (size 1 1) (layers "F.Cu"))
+)
+`
+
+test("parseKicadSymToSchematicMetadata returns pin labels and side arrangement", () => {
+  const { pinLabels, schPortArrangement } =
+    parseKicadSymToSchematicMetadata(FOUR_PIN_SYM)
+
+  expect(pinLabels).toEqual({
+    pin1: "VCC",
+    pin2: "GND",
+    pin3: "SDA",
+    pin4: "SCL",
+  })
+
+  expect(schPortArrangement.leftSide?.pins).toEqual(["pin1", "pin2"])
+  expect(schPortArrangement.leftSide?.direction).toBe("top-to-bottom")
+  expect(schPortArrangement.rightSide?.pins).toEqual(["pin3", "pin4"])
+  expect(schPortArrangement.rightSide?.direction).toBe("top-to-bottom")
+})
+
+test("parseKicadModToCircuitJson enriches source_component with kicad_sym metadata", async () => {
+  const circuitJson = await parseKicadModToCircuitJson(FOUR_PIN_MOD, {
+    kicadSym: FOUR_PIN_SYM,
+  })
+
+  const src = circuitJson.find((el) => el.type === "source_component") as any
+  expect(src).toBeDefined()
+  expect(src.pinLabels).toEqual({
+    pin1: "VCC",
+    pin2: "GND",
+    pin3: "SDA",
+    pin4: "SCL",
+  })
+  expect(src.schPortArrangement?.leftSide?.pins).toEqual(["pin1", "pin2"])
+  expect(src.schPortArrangement?.rightSide?.pins).toEqual(["pin3", "pin4"])
+})
+
+test("parseKicadModToCircuitJson without kicadSym leaves metadata absent", async () => {
+  const circuitJson = await parseKicadModToCircuitJson(FOUR_PIN_MOD)
+  const src = circuitJson.find((el) => el.type === "source_component") as any
+  expect(src).toBeDefined()
+  expect(src.pinLabels).toBeUndefined()
+  expect(src.schPortArrangement).toBeUndefined()
+})
+
+test("parseKicadSymToSchematicMetadata ignores no_connect pins", () => {
+  const symWithNoConnect = `
+(kicad_symbol_lib
+  (version 20231120)
+  (symbol "Test:TwoPlusHidden"
+    (symbol "TwoPlusHidden_0_1"
+      (pin input line (at -5.08 2.54 0) (length 2.54)
+        (name "A" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27)))))
+      (pin no_connect line (at -5.08 0 0) (length 2.54)
+        (name "NC" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27)))))
+      (pin output line (at 5.08 2.54 180) (length 2.54)
+        (name "B" (effects (font (size 1.27 1.27))))
+        (number "3" (effects (font (size 1.27 1.27)))))
+    )
+  )
+)
+  `
+  const { pinLabels } = parseKicadSymToSchematicMetadata(symWithNoConnect)
+  expect(Object.keys(pinLabels)).not.toContain("pin2")
+  expect(pinLabels.pin1).toBe("A")
+  expect(pinLabels.pin3).toBe("B")
+})
+
+test("parseKicadSymToSchematicMetadata handles top/bottom pins", () => {
+  const symTopBottom = `
+(kicad_symbol_lib
+  (version 20231120)
+  (symbol "Test:TopBottom"
+    (symbol "TopBottom_0_1"
+      (pin input line (at 0 5.08 270) (length 2.54)
+        (name "TOP1" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27)))))
+      (pin input line (at 2.54 5.08 270) (length 2.54)
+        (name "TOP2" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27)))))
+      (pin output line (at 0 -5.08 90) (length 2.54)
+        (name "BOT1" (effects (font (size 1.27 1.27))))
+        (number "3" (effects (font (size 1.27 1.27)))))
+    )
+  )
+)
+  `
+  const { schPortArrangement } = parseKicadSymToSchematicMetadata(symTopBottom)
+  expect(schPortArrangement.topSide?.pins).toEqual(["pin1", "pin2"])
+  expect(schPortArrangement.topSide?.direction).toBe("left-to-right")
+  expect(schPortArrangement.bottomSide?.pins).toEqual(["pin3"])
+})


### PR DESCRIPTION
Fixes #114

## What this adds

Parses optional `.kicad_sym` files to enrich circuit JSON with schematic metadata:

- **`pinLabels`** — maps `pin1`, `pin2`, … to human-readable names from the symbol
- **`schPortArrangement`** — groups pins by side (left/right/top/bottom) with ordering

### Library usage

```ts
import { parseKicadModToCircuitJson, parseKicadSymToSchematicMetadata } from 'kicad-component-converter'

// Combined mod + sym
const circuitJson = await parseKicadModToCircuitJson(kicadModStr, { kicadSym: kicadSymStr })

// Metadata only (no footprint needed)
const { pinLabels, schPortArrangement } = parseKicadSymToSchematicMetadata(kicadSymStr)
```

### Web UI

- Shows a **KiCad Symbol File** status row (`➖` when not provided, `✅` when loaded)
- Automatically passes `kicad_sym` content to the processor when present
- Existing drag-and-drop / paste / file-picker already accepted `.kicad_sym` — now it's actually used

## Implementation details

- Uses the existing `s-expression` library (already a dep) for S-expression parsing
- **Skips invisible / no-connect pins** (`no_connect` type or `hide` attribute)
- **Pin side detection** from KiCad rotation angle: 0°→left, 180°→right, 90°→bottom, 270°→top
- **Sorted within each side**: top-to-bottom (Y descending) on left/right; left-to-right (X ascending) on top/bottom
- Handles multi-symbol files by recursively scanning all pin nodes

## Tests

Five focused tests in `tests/parse-kicad-sym.test.ts`:
1. Labels and left/right arrangement from a 4-pin symbol
2. Combined `parseKicadModToCircuitJson` with `kicadSym` enriches `source_component`
3. Without `kicadSym`, metadata fields are absent (backwards-compat)
4. `no_connect` pins are excluded from `pinLabels`
5. Top/bottom pins grouped and ordered correctly

All 27 existing tests continue to pass.

## Verification

```bash
bun test                 # 27 pass, 0 fail
bunx tsc --noEmit        # no errors
bunx biome check src/    # no errors
```

/claim #114

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>