### PR TITLE
feat: support kicad symbol schematic metadata

### DIFF
--- a/src/convert-kicad-json-to-tscircuit-soup.ts
+++ b/src/convert-kicad-json-to-tscircuit-soup.ts
@@ -133,7 +133,10 @@ export const convertKicadJsonToTsCircuitSoup = async (
   const schematicMetadata =
     options.schematicMetadata ??
     (options.kicadSym
-      ? parseKicadSymToSchematicMetadata(options.kicadSym)
+      ? parseKicadSymToSchematicMetadata(
+          options.kicadSym,
+          kicadJson.footprint_name,
+        )
       : undefined)
 
   const circuitJson: AnyCircuitElement[] = []

--- a/src/convert-kicad-json-to-tscircuit-soup.ts
+++ b/src/convert-kicad-json-to-tscircuit-soup.ts
@@ -12,6 +12,10 @@ import type { EdgeSegment } from "./math/edge-segment"
 import { findClosedPolygons } from "./math/find-closed-polygons"
 import { polygonToPoints } from "./math/polygon-to-points"
 import { getSilkscreenFontSizeFromFpTexts } from "./get-Silkscreen-Font-Size-From-Fp-Texts"
+import {
+  parseKicadSymToSchematicMetadata,
+  type KicadSymbolSchematicMetadata,
+} from "./parse-kicad-sym-to-schematic-metadata"
 
 const degToRad = (deg: number) => (deg * Math.PI) / 180
 const rotatePoint = (x: number, y: number, deg: number) => {
@@ -89,6 +93,11 @@ const getPinNumber = (name: string | number | undefined) => {
 
 const debug = Debug("kicad-mod-converter")
 
+export interface ConvertKicadJsonToTsCircuitSoupOptions {
+  kicadSym?: string
+  schematicMetadata?: KicadSymbolSchematicMetadata
+}
+
 export const convertKicadLayerToTscircuitLayer = (kicadLayer: string) => {
   const lowerLayer = kicadLayer.toLowerCase()
   switch (lowerLayer) {
@@ -108,6 +117,7 @@ export const convertKicadLayerToTscircuitLayer = (kicadLayer: string) => {
 
 export const convertKicadJsonToTsCircuitSoup = async (
   kicadJson: KicadModJson,
+  options: ConvertKicadJsonToTsCircuitSoupOptions = {},
 ): Promise<AnyCircuitElement[]> => {
   const {
     fp_lines,
@@ -120,6 +130,11 @@ export const convertKicadJsonToTsCircuitSoup = async (
     holes,
     fp_polys,
   } = kicadJson
+  const schematicMetadata =
+    options.schematicMetadata ??
+    (options.kicadSym
+      ? parseKicadSymToSchematicMetadata(options.kicadSym)
+      : undefined)
 
   const circuitJson: AnyCircuitElement[] = []
 
@@ -135,12 +150,20 @@ export const convertKicadJsonToTsCircuitSoup = async (
     source_component_id: "source_component_0",
     center: { x: 0, y: 0 },
     rotation: 0,
-    size: { width: 0, height: 0 },
+    size: schematicMetadata?.size ?? { width: 0, height: 0 },
+    ...(schematicMetadata
+      ? {
+          port_arrangement: schematicMetadata.portArrangement,
+          port_labels: schematicMetadata.pinLabels,
+          pin_spacing: schematicMetadata.pinSpacing,
+        }
+      : {}),
   } as any)
 
   // Collect all unique port names from pads and holes
   const portNames = new Set<string>()
   const portNameToPinNumber = new Map<string, number>()
+  const portNameToSymbolPinLabel = new Map<string, string>()
   for (const pad of pads) {
     const portName = normalizePortName(pad.name)
     if (portName) {
@@ -163,6 +186,38 @@ export const convertKicadJsonToTsCircuitSoup = async (
       }
     }
   }
+  if (schematicMetadata) {
+    for (const pin of schematicMetadata.pins) {
+      const portName = normalizePortName(pin.number)
+      if (!portName) continue
+
+      portNames.add(portName)
+      const pinNumber = getPinNumber(pin.number)
+      if (pinNumber !== undefined) {
+        portNameToPinNumber.set(portName, pinNumber)
+      }
+
+      const pinLabel = schematicMetadata.pinLabels[pin.number]
+      if (pinLabel) {
+        portNameToSymbolPinLabel.set(portName, pinLabel)
+      }
+    }
+  }
+
+  const getSourcePortHints = (portName: string, pinNumber?: number) => {
+    const symbolPinLabel = portNameToSymbolPinLabel.get(portName)
+    if (!symbolPinLabel) return [portName]
+
+    return [
+      ...new Set(
+        [
+          symbolPinLabel,
+          pinNumber !== undefined ? `pin${pinNumber}` : undefined,
+          portName,
+        ].filter((hint): hint is string => Boolean(hint)),
+      ),
+    ]
+  }
 
   // Create source_port elements
   let sourcePortId = 0
@@ -171,22 +226,31 @@ export const convertKicadJsonToTsCircuitSoup = async (
     const source_port_id = `source_port_${sourcePortId++}`
     portNameToSourcePortId.set(portName, source_port_id)
     const pinNumber = portNameToPinNumber.get(portName)
+    const symbolPinLabel = portNameToSymbolPinLabel.get(portName)
     circuitJson.push({
       type: "source_port",
       source_port_id,
       source_component_id: "source_component_0",
       name: portName,
-      port_hints: [portName],
+      port_hints: getSourcePortHints(portName, pinNumber),
       pin_number: pinNumber,
-      pin_label: pinNumber !== undefined ? `pin${pinNumber}` : undefined,
+      pin_label:
+        symbolPinLabel ??
+        (pinNumber !== undefined ? `pin${pinNumber}` : undefined),
     } as any)
+    const schematicPortMetadata = schematicMetadata?.portPositions[portName]
     circuitJson.push({
       type: "schematic_port",
       schematic_port_id: `schematic_port_${sourcePortId++}`,
       source_port_id,
       schematic_component_id: "schematic_component_0",
-      center: { x: 0, y: 0 },
-    })
+      center: schematicPortMetadata?.center ?? { x: 0, y: 0 },
+      facing_direction: schematicPortMetadata?.facingDirection,
+      side_of_component: schematicPortMetadata?.sideOfComponent,
+      distance_from_component_edge: schematicPortMetadata ? 0.4 : undefined,
+      pin_number: pinNumber,
+      display_pin_label: schematicPortMetadata?.displayPinLabel,
+    } as any)
   }
 
   let minX = Number.POSITIVE_INFINITY

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
 export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"
+export { parseKicadSymToSchematicMetadata } from "./parse-kicad-sym-to-schematic-metadata"

--- a/src/parse-kicad-mod-to-circuit-json.ts
+++ b/src/parse-kicad-mod-to-circuit-json.ts
@@ -2,11 +2,20 @@ import type { AnyCircuitElement } from "circuit-json"
 import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 import { convertKicadJsonToTsCircuitSoup as convertKicadJsonToCircuitJson } from "./convert-kicad-json-to-tscircuit-soup"
 
+export interface ParseKicadModToCircuitJsonOptions {
+  kicadSym?: string
+}
+
 export const parseKicadModToCircuitJson = async (
   kicadMod: string,
+  optionsOrKicadSym?: ParseKicadModToCircuitJsonOptions | string,
 ): Promise<AnyCircuitElement[]> => {
+  const options =
+    typeof optionsOrKicadSym === "string"
+      ? { kicadSym: optionsOrKicadSym }
+      : (optionsOrKicadSym ?? {})
   const kicadJson = parseKicadModToKicadJson(kicadMod)
 
-  const circuitJson = await convertKicadJsonToCircuitJson(kicadJson)
+  const circuitJson = await convertKicadJsonToCircuitJson(kicadJson, options)
   return circuitJson as any
 }

--- a/src/parse-kicad-sym-to-schematic-metadata.ts
+++ b/src/parse-kicad-sym-to-schematic-metadata.ts
@@ -1,0 +1,368 @@
+import parseSExpression from "s-expression"
+
+type SExprNode = unknown[] & { 0?: unknown }
+
+export type SchematicArrangementPin = number | string
+
+export interface ParsedKicadSymbolPin {
+  name: string
+  number: string
+  x: number
+  y: number
+  rotation: number
+  side: "left" | "right" | "top" | "bottom"
+  arrangementPin: SchematicArrangementPin
+}
+
+export interface KicadSymbolSchematicMetadata {
+  pins: ParsedKicadSymbolPin[]
+  pinLabels: Record<string, string>
+  portArrangement: {
+    left_side?: {
+      pins: SchematicArrangementPin[]
+      direction: "top-to-bottom" | "bottom-to-top"
+    }
+    right_side?: {
+      pins: SchematicArrangementPin[]
+      direction: "top-to-bottom" | "bottom-to-top"
+    }
+    top_side?: {
+      pins: SchematicArrangementPin[]
+      direction: "left-to-right" | "right-to-left"
+    }
+    bottom_side?: {
+      pins: SchematicArrangementPin[]
+      direction: "left-to-right" | "right-to-left"
+    }
+  }
+  size: { width: number; height: number }
+  pinSpacing: number
+  portPositions: Record<
+    string,
+    {
+      center: { x: number; y: number }
+      facingDirection: "up" | "down" | "left" | "right"
+      sideOfComponent: "top" | "bottom" | "left" | "right"
+      displayPinLabel?: string
+    }
+  >
+}
+
+const PIN_SPACING = 0.2
+const PORT_DISTANCE_FROM_EDGE = 0.4
+
+const isNode = (value: unknown): value is SExprNode => Array.isArray(value)
+
+const atomToString = (value: unknown): string | undefined => {
+  if (value === undefined || value === null) return undefined
+  const raw = (value as any)?.valueOf?.() ?? value
+  if (raw === undefined || raw === null) return undefined
+  return `${raw}`
+}
+
+const atomToNumber = (value: unknown): number | undefined => {
+  const text = atomToString(value)
+  if (!text) return undefined
+  const parsed = Number.parseFloat(text)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+const nodeName = (node: unknown): string | undefined => {
+  if (!isNode(node)) return undefined
+  return atomToString(node[0])
+}
+
+const findChildNode = (node: SExprNode, key: string): SExprNode | undefined =>
+  node.find((child) => isNode(child) && nodeName(child) === key) as
+    | SExprNode
+    | undefined
+
+const findDirectChildSymbols = (node: SExprNode) =>
+  node.filter((child) => nodeName(child) === "symbol") as SExprNode[]
+
+const findAllNodesByName = (node: unknown, key: string): SExprNode[] => {
+  if (!isNode(node)) return []
+
+  const matches: SExprNode[] = []
+  if (nodeName(node) === key) {
+    matches.push(node)
+  }
+
+  for (const child of node) {
+    if (isNode(child)) {
+      matches.push(...findAllNodesByName(child, key))
+    }
+  }
+
+  return matches
+}
+
+const getSymbolCandidates = (root: SExprNode) => {
+  if (nodeName(root) === "symbol") return [root]
+
+  const directSymbols = findDirectChildSymbols(root)
+  if (directSymbols.length > 0) return directSymbols
+
+  return findAllNodesByName(root, "symbol")
+}
+
+const hasPins = (node: SExprNode) => findAllNodesByName(node, "pin").length > 0
+
+const normalizeRotation = (rotation: number) => {
+  const normalized = ((rotation % 360) + 360) % 360
+  const nearestRightAngle = Math.round(normalized / 90) * 90
+  if (Math.abs(normalized - nearestRightAngle) < 0.0001) {
+    return nearestRightAngle % 360
+  }
+  return normalized
+}
+
+const getSideFromRotation = (
+  rotation: number,
+): ParsedKicadSymbolPin["side"] | undefined => {
+  switch (normalizeRotation(rotation)) {
+    case 0:
+      return "left"
+    case 180:
+      return "right"
+    case 90:
+      return "bottom"
+    case 270:
+      return "top"
+  }
+}
+
+const getArrangementPin = (pinNumber: string): SchematicArrangementPin => {
+  const asNumber = Number(pinNumber)
+  return Number.isFinite(asNumber) && `${asNumber}` === pinNumber
+    ? asNumber
+    : pinNumber
+}
+
+const parsePinNode = (
+  pinNode: SExprNode,
+): Omit<ParsedKicadSymbolPin, "side"> | null => {
+  const at = findChildNode(pinNode, "at")
+  const name = findChildNode(pinNode, "name")
+  const number = findChildNode(pinNode, "number")
+  const x = atomToNumber(at?.[1])
+  const y = atomToNumber(at?.[2])
+  const rotation = atomToNumber(at?.[3]) ?? 0
+  const pinNumber = atomToString(number?.[1])
+
+  if (!pinNumber || x === undefined || y === undefined) {
+    return null
+  }
+
+  return {
+    name: atomToString(name?.[1]) ?? "",
+    number: pinNumber,
+    x,
+    y,
+    rotation,
+    arrangementPin: getArrangementPin(pinNumber),
+  }
+}
+
+const getFallbackSide = (
+  pin: Omit<ParsedKicadSymbolPin, "side">,
+  bounds: { minX: number; maxX: number; minY: number; maxY: number },
+): ParsedKicadSymbolPin["side"] => {
+  const distances = [
+    { side: "left" as const, distance: Math.abs(pin.x - bounds.minX) },
+    { side: "right" as const, distance: Math.abs(pin.x - bounds.maxX) },
+    { side: "bottom" as const, distance: Math.abs(pin.y - bounds.minY) },
+    { side: "top" as const, distance: Math.abs(pin.y - bounds.maxY) },
+  ]
+
+  return distances.sort((a, b) => a.distance - b.distance)[0].side
+}
+
+const compareArrangementPins = (
+  a: SchematicArrangementPin,
+  b: SchematicArrangementPin,
+) => {
+  if (typeof a === "number" && typeof b === "number") return a - b
+  return `${a}`.localeCompare(`${b}`, undefined, { numeric: true })
+}
+
+const sortPinsForSide = (
+  pins: ParsedKicadSymbolPin[],
+  side: ParsedKicadSymbolPin["side"],
+) =>
+  [...pins].sort((a, b) => {
+    if (side === "left" || side === "right") {
+      const yDiff = b.y - a.y
+      if (yDiff !== 0) return yDiff
+    } else {
+      const xDiff = a.x - b.x
+      if (xDiff !== 0) return xDiff
+    }
+
+    return compareArrangementPins(a.arrangementPin, b.arrangementPin)
+  })
+
+const isVisiblePinLabel = (label: string) => label.length > 0 && label !== "~"
+
+const buildPortArrangement = (pins: ParsedKicadSymbolPin[]) => {
+  const bySide = {
+    left: sortPinsForSide(
+      pins.filter((pin) => pin.side === "left"),
+      "left",
+    ),
+    right: sortPinsForSide(
+      pins.filter((pin) => pin.side === "right"),
+      "right",
+    ),
+    top: sortPinsForSide(
+      pins.filter((pin) => pin.side === "top"),
+      "top",
+    ),
+    bottom: sortPinsForSide(
+      pins.filter((pin) => pin.side === "bottom"),
+      "bottom",
+    ),
+  }
+
+  const portArrangement: KicadSymbolSchematicMetadata["portArrangement"] = {}
+  if (bySide.left.length > 0) {
+    portArrangement.left_side = {
+      pins: bySide.left.map((pin) => pin.arrangementPin),
+      direction: "top-to-bottom",
+    }
+  }
+  if (bySide.right.length > 0) {
+    portArrangement.right_side = {
+      pins: bySide.right.map((pin) => pin.arrangementPin),
+      direction: "top-to-bottom",
+    }
+  }
+  if (bySide.top.length > 0) {
+    portArrangement.top_side = {
+      pins: bySide.top.map((pin) => pin.arrangementPin),
+      direction: "left-to-right",
+    }
+  }
+  if (bySide.bottom.length > 0) {
+    portArrangement.bottom_side = {
+      pins: bySide.bottom.map((pin) => pin.arrangementPin),
+      direction: "left-to-right",
+    }
+  }
+
+  return { bySide, portArrangement }
+}
+
+const buildSize = (
+  bySide: Record<ParsedKicadSymbolPin["side"], ParsedKicadSymbolPin[]>,
+) => {
+  const verticalPinCount = Math.max(bySide.left.length, bySide.right.length)
+  const horizontalPinCount = Math.max(bySide.top.length, bySide.bottom.length)
+
+  return {
+    width: Math.max(0.4, (horizontalPinCount + 1) * PIN_SPACING),
+    height: Math.max(0.4, (verticalPinCount + 1) * PIN_SPACING),
+  }
+}
+
+const buildPortPositions = (
+  bySide: Record<ParsedKicadSymbolPin["side"], ParsedKicadSymbolPin[]>,
+  size: { width: number; height: number },
+) => {
+  const portPositions: KicadSymbolSchematicMetadata["portPositions"] = {}
+  const xBySide = {
+    left: -size.width / 2 - PORT_DISTANCE_FROM_EDGE,
+    right: size.width / 2 + PORT_DISTANCE_FROM_EDGE,
+    top: 0,
+    bottom: 0,
+  }
+  const yBySide = {
+    left: 0,
+    right: 0,
+    top: size.height / 2 + PORT_DISTANCE_FROM_EDGE,
+    bottom: -size.height / 2 - PORT_DISTANCE_FROM_EDGE,
+  }
+  const facingDirectionBySide = {
+    left: "left" as const,
+    right: "right" as const,
+    top: "up" as const,
+    bottom: "down" as const,
+  }
+
+  for (const [side, pins] of Object.entries(bySide) as Array<
+    [ParsedKicadSymbolPin["side"], ParsedKicadSymbolPin[]]
+  >) {
+    pins.forEach((pin, index) => {
+      const center =
+        side === "left" || side === "right"
+          ? {
+              x: xBySide[side],
+              y: ((pins.length - 1) / 2 - index) * PIN_SPACING,
+            }
+          : {
+              x: (index - (pins.length - 1) / 2) * PIN_SPACING,
+              y: yBySide[side],
+            }
+
+      portPositions[pin.number] = {
+        center,
+        facingDirection: facingDirectionBySide[side],
+        sideOfComponent: side,
+        displayPinLabel: isVisiblePinLabel(pin.name) ? pin.name : undefined,
+      }
+    })
+  }
+
+  return portPositions
+}
+
+export const parseKicadSymToSchematicMetadata = (
+  kicadSym: string,
+): KicadSymbolSchematicMetadata | undefined => {
+  const root = parseSExpression(kicadSym) as SExprNode
+  const symbolNode = getSymbolCandidates(root).find(hasPins)
+  if (!symbolNode) return undefined
+
+  const parsedPins = findAllNodesByName(symbolNode, "pin")
+    .map(parsePinNode)
+    .filter((pin): pin is Omit<ParsedKicadSymbolPin, "side"> => pin !== null)
+
+  if (parsedPins.length === 0) return undefined
+
+  const bounds = {
+    minX: Math.min(...parsedPins.map((pin) => pin.x)),
+    maxX: Math.max(...parsedPins.map((pin) => pin.x)),
+    minY: Math.min(...parsedPins.map((pin) => pin.y)),
+    maxY: Math.max(...parsedPins.map((pin) => pin.y)),
+  }
+
+  const pinsByNumber = new Map<string, ParsedKicadSymbolPin>()
+  for (const pin of parsedPins) {
+    if (pinsByNumber.has(pin.number)) continue
+    pinsByNumber.set(pin.number, {
+      ...pin,
+      side: getSideFromRotation(pin.rotation) ?? getFallbackSide(pin, bounds),
+    })
+  }
+
+  const pins = [...pinsByNumber.values()]
+  const { bySide, portArrangement } = buildPortArrangement(pins)
+  const size = buildSize(bySide)
+  const portPositions = buildPortPositions(bySide, size)
+  const pinLabels: Record<string, string> = {}
+
+  for (const pin of pins) {
+    if (isVisiblePinLabel(pin.name)) {
+      pinLabels[pin.number] = pin.name
+    }
+  }
+
+  return {
+    pins,
+    pinLabels,
+    portArrangement,
+    size,
+    pinSpacing: PIN_SPACING,
+    portPositions,
+  }
+}

--- a/src/parse-kicad-sym-to-schematic-metadata.ts
+++ b/src/parse-kicad-sym-to-schematic-metadata.ts
@@ -80,6 +80,13 @@ const findChildNode = (node: SExprNode, key: string): SExprNode | undefined =>
 const findDirectChildSymbols = (node: SExprNode) =>
   node.filter((child) => nodeName(child) === "symbol") as SExprNode[]
 
+const getSymbolName = (node: SExprNode) => atomToString(node[1])
+
+const normalizeSymbolName = (name: string | undefined) => {
+  const parts = name?.split(":")
+  return parts?.[parts.length - 1]?.toLowerCase()
+}
+
 const findAllNodesByName = (node: unknown, key: string): SExprNode[] => {
   if (!isNode(node)) return []
 
@@ -107,6 +114,21 @@ const getSymbolCandidates = (root: SExprNode) => {
 }
 
 const hasPins = (node: SExprNode) => findAllNodesByName(node, "pin").length > 0
+
+const findSymbolWithPins = (root: SExprNode, symbolName?: string) => {
+  const candidates = getSymbolCandidates(root).filter(hasPins)
+  const normalizedSymbolName = normalizeSymbolName(symbolName)
+
+  if (normalizedSymbolName) {
+    const matchingSymbol = candidates.find(
+      (candidate) =>
+        normalizeSymbolName(getSymbolName(candidate)) === normalizedSymbolName,
+    )
+    if (matchingSymbol) return matchingSymbol
+  }
+
+  return candidates[0]
+}
 
 const normalizeRotation = (rotation: number) => {
   const normalized = ((rotation % 360) + 360) % 360
@@ -318,9 +340,10 @@ const buildPortPositions = (
 
 export const parseKicadSymToSchematicMetadata = (
   kicadSym: string,
+  symbolName?: string,
 ): KicadSymbolSchematicMetadata | undefined => {
   const root = parseSExpression(kicadSym) as SExprNode
-  const symbolNode = getSymbolCandidates(root).find(hasPins)
+  const symbolNode = findSymbolWithPins(root, symbolName)
   if (!symbolNode) return undefined
 
   const parsedPins = findAllNodesByName(symbolNode, "pin")

--- a/src/site/App.tsx
+++ b/src/site/App.tsx
@@ -26,7 +26,9 @@ export const App = () => {
     setError(null)
     let circuitJson: any
     try {
-      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod, {
+        kicadSym: filesAdded.kicad_sym,
+      })
       updateCircuitJson(circuitJson as any)
     } catch (err: any) {
       setError(`Error parsing KiCad Mod file: ${err.toString()}`)
@@ -55,7 +57,11 @@ export const App = () => {
         file.trim().startsWith("(footprint")
       ) {
         addFile("kicad_mod", file)
-      } else if (fileName.endsWith(".kicad_sym")) {
+      } else if (
+        fileName.endsWith(".kicad_sym") ||
+        file.trim().startsWith("(kicad_symbol_lib") ||
+        file.trim().startsWith("(symbol")
+      ) {
         addFile("kicad_sym", file)
       } else {
         setError("Unsupported file type")
@@ -84,7 +90,10 @@ export const App = () => {
       if (!content) return
       if (content.trim().startsWith("(footprint")) {
         addDroppedFile("kicad_mod", content)
-      } else if (content.trim().startsWith("(symbol")) {
+      } else if (
+        content.trim().startsWith("(symbol") ||
+        content.trim().startsWith("(kicad_symbol_lib")
+      ) {
         addDroppedFile("kicad_sym", content)
       } else {
         setError("Unsupported file type (file an issue if we're wrong)")

--- a/tests/kicad-sym-schematic-metadata.test.ts
+++ b/tests/kicad-sym-schematic-metadata.test.ts
@@ -1,0 +1,122 @@
+import { expect, test } from "bun:test"
+import {
+  parseKicadModToCircuitJson,
+  parseKicadSymToSchematicMetadata,
+} from "src"
+
+const kicadMod = `(footprint "Issue114Part"
+  (version 20240101)
+  (generator "issue-114-test")
+  (layer "F.Cu")
+  (pad "1" smd rect (at -1 1) (size 0.5 0.5) (layers "F.Cu"))
+  (pad "2" smd rect (at 1 0) (size 0.5 0.5) (layers "F.Cu"))
+  (pad "3" smd rect (at 0 1) (size 0.5 0.5) (layers "F.Cu"))
+  (pad "4" smd rect (at 0 -1) (size 0.5 0.5) (layers "F.Cu"))
+  (pad "5" smd rect (at -1 -1) (size 0.5 0.5) (layers "F.Cu"))
+)`
+
+const kicadSym = `(kicad_symbol_lib
+  (version 20240101)
+  (generator "issue-114-test")
+  (symbol "Issue114Part"
+    (property "Reference" "U" (at 0 6.35 0)
+      (effects (font (size 1.27 1.27))))
+    (symbol "Issue114Part_0_1"
+      (pin input line (at -5.08 2.54 0) (length 2.54)
+        (name "VIN" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27)))))
+      (pin input line (at -5.08 -2.54 0) (length 2.54)
+        (name "EN" (effects (font (size 1.27 1.27))))
+        (number "5" (effects (font (size 1.27 1.27)))))
+      (pin output line (at 5.08 0 180) (length 2.54)
+        (name "OUT" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27))))))
+    (symbol "Issue114Part_1_1"
+      (pin power_in line (at -1.27 5.08 270) (length 2.54)
+        (name "VCC" (effects (font (size 1.27 1.27))))
+        (number "3" (effects (font (size 1.27 1.27)))))
+      (pin power_in line (at 1.27 -5.08 90) (length 2.54)
+        (name "GND" (effects (font (size 1.27 1.27))))
+        (number "4" (effects (font (size 1.27 1.27))))))
+  )
+)`
+
+test("parses nested .kicad_sym pins into labels and port arrangement", () => {
+  const metadata = parseKicadSymToSchematicMetadata(kicadSym)
+
+  expect(metadata?.pinLabels).toEqual({
+    "1": "VIN",
+    "2": "OUT",
+    "3": "VCC",
+    "4": "GND",
+    "5": "EN",
+  })
+  expect(metadata?.portArrangement).toEqual({
+    left_side: { pins: [1, 5], direction: "top-to-bottom" },
+    right_side: { pins: [2], direction: "top-to-bottom" },
+    top_side: { pins: [3], direction: "left-to-right" },
+    bottom_side: { pins: [4], direction: "left-to-right" },
+  })
+  expect(metadata?.pins.find((pin) => pin.number === "1")?.side).toBe("left")
+  expect(metadata?.pins.find((pin) => pin.number === "4")?.side).toBe("bottom")
+})
+
+test("wires optional .kicad_sym metadata into converted circuit json", async () => {
+  const circuitJson = (await parseKicadModToCircuitJson(
+    kicadMod,
+    kicadSym,
+  )) as any[]
+  const schematicComponent = circuitJson.find(
+    (elm) => elm.type === "schematic_component",
+  )
+  const sourcePorts = circuitJson.filter((elm) => elm.type === "source_port")
+  const schematicPorts = circuitJson.filter(
+    (elm) => elm.type === "schematic_port",
+  )
+  const sourcePort1 = sourcePorts.find((port) => port.name === "1")
+  const schematicPort1 = schematicPorts.find(
+    (port) => port.source_port_id === sourcePort1.source_port_id,
+  )
+
+  expect(schematicComponent.port_arrangement).toEqual({
+    left_side: { pins: [1, 5], direction: "top-to-bottom" },
+    right_side: { pins: [2], direction: "top-to-bottom" },
+    top_side: { pins: [3], direction: "left-to-right" },
+    bottom_side: { pins: [4], direction: "left-to-right" },
+  })
+  expect(schematicComponent.port_labels).toEqual({
+    "1": "VIN",
+    "2": "OUT",
+    "3": "VCC",
+    "4": "GND",
+    "5": "EN",
+  })
+  expect(sourcePort1.pin_label).toBe("VIN")
+  expect(sourcePort1.port_hints).toEqual(["VIN", "pin1", "1"])
+  expect(schematicPort1.display_pin_label).toBe("VIN")
+  expect(schematicPort1.side_of_component).toBe("left")
+  expect(schematicPort1.facing_direction).toBe("left")
+  expect(schematicPort1.center.x).toBeLessThan(0)
+})
+
+test("footprint-only conversion keeps existing schematic fallback", async () => {
+  const circuitJson = (await parseKicadModToCircuitJson(kicadMod)) as any[]
+  const schematicComponent = circuitJson.find(
+    (elm) => elm.type === "schematic_component",
+  )
+  const sourcePort1 = circuitJson.find(
+    (elm) => elm.type === "source_port" && elm.name === "1",
+  )
+  const schematicPort1 = circuitJson.find(
+    (elm) =>
+      elm.type === "schematic_port" &&
+      elm.source_port_id === sourcePort1.source_port_id,
+  )
+
+  expect(schematicComponent.port_arrangement).toBeUndefined()
+  expect(schematicComponent.port_labels).toBeUndefined()
+  expect(sourcePort1.pin_label).toBe("pin1")
+  expect(sourcePort1.port_hints).toEqual(["1"])
+  expect(schematicPort1.center).toEqual({ x: 0, y: 0 })
+  expect(schematicPort1.display_pin_label).toBeUndefined()
+})

--- a/tests/kicad-sym-schematic-metadata.test.ts
+++ b/tests/kicad-sym-schematic-metadata.test.ts
@@ -41,6 +41,21 @@ const kicadSym = `(kicad_symbol_lib
   )
 )`
 
+const multiSymbolKicadSym = `(kicad_symbol_lib
+  (version 20240101)
+  (generator "issue-114-test")
+  (symbol "OtherPart"
+    (symbol "OtherPart_0_1"
+      (pin input line (at -2.54 0 0) (length 2.54)
+        (name "WRONG" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27)))))))
+  (symbol "Issue114Part"
+    (symbol "Issue114Part_0_1"
+      (pin input line (at -5.08 0 0) (length 2.54)
+        (name "VIN" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27)))))))
+)`
+
 test("parses nested .kicad_sym pins into labels and port arrangement", () => {
   const metadata = parseKicadSymToSchematicMetadata(kicadSym)
 
@@ -97,6 +112,23 @@ test("wires optional .kicad_sym metadata into converted circuit json", async () 
   expect(schematicPort1.side_of_component).toBe("left")
   expect(schematicPort1.facing_direction).toBe("left")
   expect(schematicPort1.center.x).toBeLessThan(0)
+})
+
+test("selects matching symbol from multi-symbol libraries", async () => {
+  const metadata = parseKicadSymToSchematicMetadata(
+    multiSymbolKicadSym,
+    "Issue114Part",
+  )
+  expect(metadata?.pinLabels).toEqual({ "1": "VIN" })
+
+  const circuitJson = (await parseKicadModToCircuitJson(
+    kicadMod,
+    multiSymbolKicadSym,
+  )) as any[]
+  const schematicComponent = circuitJson.find(
+    (elm) => elm.type === "schematic_component",
+  )
+  expect(schematicComponent.port_labels).toEqual({ "1": "VIN" })
 })
 
 test("footprint-only conversion keeps existing schematic fallback", async () => {


### PR DESCRIPTION
## Summary
- Adds an optional KiCad symbol parser that extracts pin numbers, labels, and pin geometry from .kicad_sym input.
- Threads parsed symbol metadata into the conversion path so schematic components get richer pin labels and port arrangement data.
- Supports symbol-only metadata extraction and footprint + symbol enrichment while preserving footprint-only behavior.
- Wires the site flow to accept an optional symbol file alongside the footprint file.

## Validation
- npx bun test tests/kicad-sym-schematic-metadata.test.ts
- npx bun test
- npm run build
- npx tsc --noEmit
- npm run build:site
- npx biome format src/parse-kicad-sym-to-schematic-metadata.ts src/convert-kicad-json-to-tscircuit-soup.ts src/parse-kicad-mod-to-circuit-json.ts src/index.ts src/site/App.tsx tests/kicad-sym-schematic-metadata.test.ts
- git diff --check

Fixes #114
