### PR TITLE
feat: support kicad_sym metadata in schematic view

### DIFF
--- a/src/convert-kicad-json-to-tscircuit-soup.ts
+++ b/src/convert-kicad-json-to-tscircuit-soup.ts
@@ -1,4 +1,5 @@
 import type { KicadModJson } from "./kicad-zod"
+import type { KicadSymSchematicProps } from "./parse-kicad-sym-to-schematic-props"
 import type {
   AnyCircuitElement,
   PcbHole,
@@ -108,6 +109,7 @@ export const convertKicadLayerToTscircuitLayer = (kicadLayer: string) => {
 
 export const convertKicadJsonToTsCircuitSoup = async (
   kicadJson: KicadModJson,
+  schematicProps?: Partial<KicadSymSchematicProps>,
 ): Promise<AnyCircuitElement[]> => {
   const {
     fp_lines,
@@ -136,6 +138,12 @@ export const convertKicadJsonToTsCircuitSoup = async (
     center: { x: 0, y: 0 },
     rotation: 0,
     size: { width: 0, height: 0 },
+    ...(schematicProps?.schPortArrangement
+      ? { port_arrangement: schematicProps.schPortArrangement }
+      : {}),
+    ...(schematicProps?.pinLabels
+      ? { port_labels: schematicProps.pinLabels }
+      : {}),
   } as any)
 
   // Collect all unique port names from pads and holes

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
+export { parseKicadSymToSchematicProps } from "./parse-kicad-sym-to-schematic-props"
 export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"

--- a/src/parse-kicad-mod-to-circuit-json.ts
+++ b/src/parse-kicad-mod-to-circuit-json.ts
@@ -1,12 +1,17 @@
 import type { AnyCircuitElement } from "circuit-json"
+import type { KicadSymSchematicProps } from "./parse-kicad-sym-to-schematic-props"
 import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 import { convertKicadJsonToTsCircuitSoup as convertKicadJsonToCircuitJson } from "./convert-kicad-json-to-tscircuit-soup"
 
 export const parseKicadModToCircuitJson = async (
   kicadMod: string,
+  schematicProps?: Partial<KicadSymSchematicProps>,
 ): Promise<AnyCircuitElement[]> => {
   const kicadJson = parseKicadModToKicadJson(kicadMod)
 
-  const circuitJson = await convertKicadJsonToCircuitJson(kicadJson)
+  const circuitJson = await convertKicadJsonToCircuitJson(
+    kicadJson,
+    schematicProps,
+  )
   return circuitJson as any
 }

--- a/src/parse-kicad-sym-to-schematic-props.ts
+++ b/src/parse-kicad-sym-to-schematic-props.ts
@@ -1,0 +1,129 @@
+import parseSExpression from "s-expression"
+
+type PinSide = "left_side" | "right_side" | "top_side" | "bottom_side"
+
+export interface KicadSymSchematicProps {
+  schPortArrangement: {
+    left_side?: { pins: number[]; direction?: "top-to-bottom" }
+    right_side?: { pins: number[]; direction?: "top-to-bottom" }
+    top_side?: { pins: number[]; direction?: "left-to-right" }
+    bottom_side?: { pins: number[]; direction?: "left-to-right" }
+  }
+  pinLabels: Record<string, string>
+}
+
+interface KicadSymbolPin {
+  number: number
+  name?: string
+  x: number
+  y: number
+  rotation: number
+}
+
+const atomValue = (value: any) => value?.valueOf?.() ?? value
+
+const findChild = (row: any[], childName: string) =>
+  row.find((child) => Array.isArray(child) && atomValue(child[0]) === childName)
+
+const collectRows = (node: any, rowName: string, rows: any[] = []) => {
+  if (!Array.isArray(node)) return rows
+  if (atomValue(node[0]) === rowName) rows.push(node)
+  for (const child of node) collectRows(child, rowName, rows)
+  return rows
+}
+
+const normalizeRotation = (rotation: number) => ((rotation % 360) + 360) % 360
+
+const getPinSide = (pin: KicadSymbolPin): PinSide => {
+  switch (normalizeRotation(pin.rotation)) {
+    case 0:
+      return "left_side"
+    case 90:
+      return "bottom_side"
+    case 180:
+      return "right_side"
+    case 270:
+      return "top_side"
+    default:
+      return Math.abs(pin.x) >= Math.abs(pin.y)
+        ? pin.x <= 0
+          ? "left_side"
+          : "right_side"
+        : pin.y <= 0
+          ? "bottom_side"
+          : "top_side"
+  }
+}
+
+const sortPinsForSide = (side: PinSide, pins: KicadSymbolPin[]) => {
+  return [...pins].sort((a, b) =>
+    side === "top_side" || side === "bottom_side"
+      ? a.x - b.x || a.number - b.number
+      : b.y - a.y || a.number - b.number,
+  )
+}
+
+const parsePin = (row: any[]): KicadSymbolPin | undefined => {
+  const at = findChild(row, "at")
+  const number = findChild(row, "number")
+  if (!at || !number) return undefined
+
+  const pinNumber = Number(atomValue(number[1]))
+  if (!Number.isFinite(pinNumber)) return undefined
+
+  const name = findChild(row, "name")
+  return {
+    number: pinNumber,
+    name: name ? String(atomValue(name[1])) : undefined,
+    x: Number(atomValue(at[1])) || 0,
+    y: Number(atomValue(at[2])) || 0,
+    rotation: Number(atomValue(at[3])) || 0,
+  }
+}
+
+export const parseKicadSymToSchematicProps = (
+  fileContent: string,
+): KicadSymSchematicProps => {
+  const kicadSExpr = parseSExpression(fileContent)
+  const pinsByNumber = new Map<number, KicadSymbolPin>()
+
+  for (const row of collectRows(kicadSExpr, "pin")) {
+    const pin = parsePin(row)
+    if (pin) pinsByNumber.set(pin.number, pin)
+  }
+
+  const pinsBySide = new Map<PinSide, KicadSymbolPin[]>()
+  const pinLabels: Record<string, string> = {}
+
+  for (const pin of pinsByNumber.values()) {
+    const side = getPinSide(pin)
+    pinsBySide.set(side, [...(pinsBySide.get(side) ?? []), pin])
+    if (pin.name) pinLabels[String(pin.number)] = pin.name
+  }
+
+  const schPortArrangement: KicadSymSchematicProps["schPortArrangement"] = {}
+
+  for (const side of [
+    "left_side",
+    "right_side",
+    "top_side",
+    "bottom_side",
+  ] as const) {
+    const pins = pinsBySide.get(side)
+    if (!pins?.length) continue
+    const sortedPins = sortPinsForSide(side, pins).map((pin) => pin.number)
+    if (side === "left_side" || side === "right_side") {
+      schPortArrangement[side] = {
+        pins: sortedPins,
+        direction: "top-to-bottom",
+      }
+    } else {
+      schPortArrangement[side] = {
+        pins: sortedPins,
+        direction: "left-to-right",
+      }
+    }
+  }
+
+  return { schPortArrangement, pinLabels }
+}

--- a/src/site/App.tsx
+++ b/src/site/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState, useRef } from "react"
 import { useStore } from "./use-store"
 import { Download, FileSearch } from "lucide-react"
 import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import { parseKicadSymToSchematicProps } from "src/parse-kicad-sym-to-schematic-props"
 import { CircuitJsonPreview } from "@tscircuit/runframe"
 import { convertCircuitJsonToTscircuit } from "circuit-json-to-tscircuit"
 import { createSnippetUrl } from "@tscircuit/create-snippet-url"
@@ -26,7 +27,13 @@ export const App = () => {
     setError(null)
     let circuitJson: any
     try {
-      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+      const schematicProps = filesAdded.kicad_sym
+        ? parseKicadSymToSchematicProps(filesAdded.kicad_sym)
+        : undefined
+      circuitJson = await parseKicadModToCircuitJson(
+        filesAdded.kicad_mod,
+        schematicProps,
+      )
       updateCircuitJson(circuitJson as any)
     } catch (err: any) {
       setError(`Error parsing KiCad Mod file: ${err.toString()}`)
@@ -55,7 +62,10 @@ export const App = () => {
         file.trim().startsWith("(footprint")
       ) {
         addFile("kicad_mod", file)
-      } else if (fileName.endsWith(".kicad_sym")) {
+      } else if (
+        fileName.endsWith(".kicad_sym") ||
+        file.trim().startsWith("(kicad_symbol_lib")
+      ) {
         addFile("kicad_sym", file)
       } else {
         setError("Unsupported file type")
@@ -84,7 +94,10 @@ export const App = () => {
       if (!content) return
       if (content.trim().startsWith("(footprint")) {
         addDroppedFile("kicad_mod", content)
-      } else if (content.trim().startsWith("(symbol")) {
+      } else if (
+        content.trim().startsWith("(symbol") ||
+        content.trim().startsWith("(kicad_symbol_lib")
+      ) {
         addDroppedFile("kicad_sym", content)
       } else {
         setError("Unsupported file type (file an issue if we're wrong)")
@@ -151,6 +164,17 @@ export const App = () => {
                 {filesAdded.kicad_mod ? "✅" : "❌"}
               </span>
               <span className="text-gray-300">KiCad Mod File</span>
+            </div>
+            <div className="flex items-center gap-2 bg-gray-800/50 p-3 rounded-md">
+              <span
+                className={
+                  filesAdded.kicad_sym ? "text-green-500" : "text-gray-500"
+                }
+              >
+                {filesAdded.kicad_sym ? "✓" : "○"}
+              </span>
+              <span className="text-gray-300">KiCad Symbol File</span>
+              <span className="text-gray-500">optional</span>
             </div>
           </div>
           <div className="flex justify-center items-center gap-2">

--- a/tests/kicad-sym-schematic-props.test.ts
+++ b/tests/kicad-sym-schematic-props.test.ts
@@ -22,13 +22,74 @@ const kicadSym = `(kicad_symbol_lib
   )
 )`
 
+const fourSidedKicadSym = `(kicad_symbol_lib
+  (version 20231120)
+  (generator "kicad_symbol_editor")
+  (symbol "Demo:FourSided"
+    (pin input line (at -5.08 2.54 0) (length 2.54)
+      (name "VIN" (effects (font (size 1.27 1.27))))
+      (number "1" (effects (font (size 1.27 1.27))))
+    )
+    (pin input line (at -5.08 -2.54 0) (length 2.54)
+      (name "EN" (effects (font (size 1.27 1.27))))
+      (number "4" (effects (font (size 1.27 1.27))))
+    )
+    (pin output line (at 5.08 2.54 180) (length 2.54)
+      (name "VOUT" (effects (font (size 1.27 1.27))))
+      (number "2" (effects (font (size 1.27 1.27))))
+    )
+    (pin passive line (at 0 -5.08 90) (length 2.54)
+      (name "GND" (effects (font (size 1.27 1.27))))
+      (number "3" (effects (font (size 1.27 1.27))))
+    )
+    (pin input line (at 0 5.08 270) (length 2.54)
+      (name "CLK" (effects (font (size 1.27 1.27))))
+      (number "5" (effects (font (size 1.27 1.27))))
+    )
+  )
+)`
+
 test("extracts schematic arrangement and labels from kicad_sym pins", () => {
   const props = parseKicadSymToSchematicProps(kicadSym)
 
-  expect(props.schPortArrangement.left_side?.pins).toEqual([1])
-  expect(props.schPortArrangement.right_side?.pins).toEqual([2])
-  expect(props.schPortArrangement.bottom_side?.pins).toEqual([3])
+  expect(props.schPortArrangement.left_side).toEqual({
+    pins: [1],
+    direction: "top-to-bottom",
+  })
+  expect(props.schPortArrangement.right_side).toEqual({
+    pins: [2],
+    direction: "top-to-bottom",
+  })
+  expect(props.schPortArrangement.bottom_side).toEqual({
+    pins: [3],
+    direction: "left-to-right",
+  })
   expect(props.pinLabels).toEqual({ 1: "VIN", 2: "VOUT", 3: "GND" })
+})
+
+test("sorts symbol pins by side using schematic orientation", () => {
+  const props = parseKicadSymToSchematicProps(fourSidedKicadSym)
+
+  expect(props.schPortArrangement.left_side).toEqual({
+    pins: [1, 4],
+    direction: "top-to-bottom",
+  })
+  expect(props.schPortArrangement.right_side?.pins).toEqual([2])
+  expect(props.schPortArrangement.bottom_side).toEqual({
+    pins: [3],
+    direction: "left-to-right",
+  })
+  expect(props.schPortArrangement.top_side).toEqual({
+    pins: [5],
+    direction: "left-to-right",
+  })
+  expect(props.pinLabels).toEqual({
+    1: "VIN",
+    2: "VOUT",
+    3: "GND",
+    4: "EN",
+    5: "CLK",
+  })
 })
 
 test("applies kicad_sym schematic props to the schematic component", async () => {

--- a/tests/kicad-sym-schematic-props.test.ts
+++ b/tests/kicad-sym-schematic-props.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs"
+import { join } from "node:path"
+import { parseKicadModToCircuitJson, parseKicadSymToSchematicProps } from "src"
+
+const kicadSym = `(kicad_symbol_lib
+  (version 20231120)
+  (generator "kicad_symbol_editor")
+  (symbol "Demo:Demo"
+    (pin input line (at -5.08 2.54 0) (length 2.54)
+      (name "VIN" (effects (font (size 1.27 1.27))))
+      (number "1" (effects (font (size 1.27 1.27))))
+    )
+    (pin output line (at 5.08 2.54 180) (length 2.54)
+      (name "VOUT" (effects (font (size 1.27 1.27))))
+      (number "2" (effects (font (size 1.27 1.27))))
+    )
+    (pin passive line (at 0 -5.08 90) (length 2.54)
+      (name "GND" (effects (font (size 1.27 1.27))))
+      (number "3" (effects (font (size 1.27 1.27))))
+    )
+  )
+)`
+
+test("extracts schematic arrangement and labels from kicad_sym pins", () => {
+  const props = parseKicadSymToSchematicProps(kicadSym)
+
+  expect(props.schPortArrangement.left_side?.pins).toEqual([1])
+  expect(props.schPortArrangement.right_side?.pins).toEqual([2])
+  expect(props.schPortArrangement.bottom_side?.pins).toEqual([3])
+  expect(props.pinLabels).toEqual({ 1: "VIN", 2: "VOUT", 3: "GND" })
+})
+
+test("applies kicad_sym schematic props to the schematic component", async () => {
+  const fileContent = fs.readFileSync(
+    join(import.meta.dirname, "fixtures/SimpleSmd.kicad_mod"),
+    "utf8",
+  )
+  const props = parseKicadSymToSchematicProps(kicadSym)
+  const circuitJson = (await parseKicadModToCircuitJson(
+    fileContent,
+    props,
+  )) as any[]
+
+  const schematicComponent = circuitJson.find(
+    (el) => el.type === "schematic_component",
+  )
+
+  expect(schematicComponent.port_arrangement.left_side.pins).toEqual([1])
+  expect(schematicComponent.port_labels).toEqual({
+    1: "VIN",
+    2: "VOUT",
+    3: "GND",
+  })
+})


### PR DESCRIPTION
## Summary
- parse optional `.kicad_sym` pin metadata into schematic `port_arrangement` and `port_labels`
- pass symbol metadata through `parseKicadModToCircuitJson` into the generated schematic component
- accept pasted/dropped `kicad_symbol_lib` content in the web viewer and show the optional symbol file state
- add regression coverage for symbol-derived schematic props, including four-sided symbol side sorting and emitted directions

## Verification
- GitHub Actions `test`: passing
- GitHub Actions `type-check`: passing
- GitHub Actions `format-check`: passing
- Vercel preview deployment: passing
- `git diff --check HEAD~1..HEAD`
- Regression coverage: four-sided `.kicad_sym` side ordering

## Demo
Preview: https://kicad-component-converter-git-fork-nightvibes3-affc27-tscircuit.vercel.app

Manual UI check:
1. Open the preview.
2. Add a `.kicad_mod` file.
3. Add an optional `.kicad_sym` file.
4. Click **Process & View**.
5. Confirm the generated schematic component includes symbol-derived `port_arrangement` and `port_labels`.

`tests/kicad-sym-schematic-props.test.ts` covers the same behavior at the circuit-json level.

Closes #114
/claim #114
