### PR TITLE
Add KiCad symbol schematic props support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
 export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"
+export {
+  addSchematicPropsToTscircuitCode,
+  applyKicadSymPropsToCircuitJson,
+  createCircuitJsonFromKicadSymProps,
+  parseKicadSymToSchematicProps,
+} from "./parse-kicad-sym-to-sch-props"

--- a/src/parse-kicad-sym-to-sch-props.ts
+++ b/src/parse-kicad-sym-to-sch-props.ts
@@ -1,0 +1,233 @@
+import type { AnyCircuitElement } from "circuit-json"
+import parseSExpression from "s-expression"
+import { getAttr } from "./get-attr"
+
+type SchSide = "leftSide" | "rightSide" | "topSide" | "bottomSide"
+type SchDirection = "top-to-bottom" | "bottom-to-top" | "left-to-right"
+
+export interface KicadSymPin {
+  number: string
+  name: string
+  at: [number, number, number?]
+}
+
+export interface KicadSymSchematicProps {
+  pinLabels: Record<string, string>
+  schPinArrangement: Partial<
+    Record<SchSide, { pins: string[]; direction: SchDirection }>
+  >
+  pins: KicadSymPin[]
+}
+
+const asString = (value: any) => `${value?.valueOf?.() ?? value}`
+
+const getTextAttr = (row: any[], key: string) => {
+  const attr = row.find((item) => Array.isArray(item) && item[0] === key)
+  return attr?.[1] !== undefined ? asString(attr[1]) : undefined
+}
+
+const collectRows = (node: any, rowName: string, rows: any[][] = []) => {
+  if (!Array.isArray(node)) return rows
+  if (node[0] === rowName) {
+    rows.push(node)
+  }
+  for (const child of node) {
+    collectRows(child, rowName, rows)
+  }
+  return rows
+}
+
+const getPinKey = (pinNumber: string) => `pin${pinNumber}`
+
+const getSideFromRotation = (rotation: number | undefined): SchSide => {
+  const normalized = (((rotation ?? 0) % 360) + 360) % 360
+  if (normalized === 180) return "rightSide"
+  if (normalized === 90) return "bottomSide"
+  if (normalized === 270) return "topSide"
+  return "leftSide"
+}
+
+const sortPinsForSide = (side: SchSide, pins: KicadSymPin[]) => {
+  return [...pins].sort((a, b) => {
+    if (side === "topSide" || side === "bottomSide") return a.at[0] - b.at[0]
+    return b.at[1] - a.at[1]
+  })
+}
+
+export const parseKicadSymToSchematicProps = (
+  fileContent: string,
+): KicadSymSchematicProps => {
+  const kicadSExpr = parseSExpression(fileContent)
+  const pinRows = collectRows(kicadSExpr, "pin")
+
+  const pins = pinRows
+    .map((row) => {
+      const number = getTextAttr(row, "number")
+      const name = getTextAttr(row, "name")
+      const at = getAttr(row, "at") as number[] | undefined
+      if (!number || !name || !at || at.length < 2) return null
+      return {
+        number,
+        name,
+        at: [at[0]!, at[1]!, at[2] ?? 0] as [number, number, number],
+      }
+    })
+    .filter((pin): pin is KicadSymPin => Boolean(pin))
+
+  const pinLabels = Object.fromEntries(
+    pins.map((pin) => [getPinKey(pin.number), pin.name]),
+  )
+
+  const groupedPins: Record<SchSide, KicadSymPin[]> = {
+    leftSide: [],
+    rightSide: [],
+    topSide: [],
+    bottomSide: [],
+  }
+
+  for (const pin of pins) {
+    groupedPins[getSideFromRotation(pin.at[2])].push(pin)
+  }
+
+  const schPinArrangement: KicadSymSchematicProps["schPinArrangement"] = {}
+  for (const side of Object.keys(groupedPins) as SchSide[]) {
+    if (groupedPins[side].length === 0) continue
+    schPinArrangement[side] = {
+      pins: sortPinsForSide(side, groupedPins[side]).map((pin) =>
+        getPinKey(pin.number),
+      ),
+      direction:
+        side === "topSide" || side === "bottomSide"
+          ? "left-to-right"
+          : "top-to-bottom",
+    }
+  }
+
+  return { pinLabels, schPinArrangement, pins }
+}
+
+export const createCircuitJsonFromKicadSymProps = (
+  props: KicadSymSchematicProps,
+): AnyCircuitElement[] => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      supplier_part_numbers: {},
+    } as any,
+    {
+      type: "schematic_component",
+      schematic_component_id: "schematic_component_0",
+      source_component_id: "source_component_0",
+      center: { x: 0, y: 0 },
+      rotation: 0,
+      size: getSchematicSize(props.pins),
+    } as any,
+  ]
+
+  props.pins.forEach((pin, index) => {
+    const sourcePortId = `source_port_${index}`
+    circuitJson.push({
+      type: "source_port",
+      source_port_id: sourcePortId,
+      source_component_id: "source_component_0",
+      name: pin.number,
+      port_hints: [pin.number, getPinKey(pin.number), pin.name],
+      pin_number: Number.isFinite(Number(pin.number))
+        ? Number(pin.number)
+        : undefined,
+      pin_label: pin.name,
+    } as any)
+    circuitJson.push({
+      type: "schematic_port",
+      schematic_port_id: `schematic_port_${index}`,
+      source_port_id: sourcePortId,
+      schematic_component_id: "schematic_component_0",
+      center: { x: pin.at[0], y: -pin.at[1] },
+    } as any)
+  })
+
+  return circuitJson
+}
+
+export const applyKicadSymPropsToCircuitJson = (
+  circuitJson: AnyCircuitElement[],
+  props: KicadSymSchematicProps,
+) => {
+  const pinByNumber = new Map(props.pins.map((pin) => [pin.number, pin]))
+  const pinByName = new Map(props.pins.map((pin) => [pin.name, pin]))
+
+  for (const element of circuitJson as any[]) {
+    if (element.type === "schematic_component") {
+      element.size = getSchematicSize(props.pins)
+    }
+    if (element.type !== "source_port") continue
+    const hints = [
+      element.name,
+      element.pin_number,
+      ...(element.port_hints ?? []),
+    ]
+      .filter((hint) => hint !== undefined && hint !== null)
+      .map(String)
+    const pin =
+      hints
+        .map((hint) => pinByNumber.get(hint) ?? pinByName.get(hint))
+        .find(Boolean) ?? undefined
+    if (!pin) continue
+    element.pin_label = pin.name
+    element.port_hints = Array.from(
+      new Set([
+        ...(element.port_hints ?? []),
+        pin.number,
+        getPinKey(pin.number),
+        pin.name,
+      ]),
+    )
+  }
+
+  for (const schematicPort of circuitJson.filter(
+    (element: any) => element.type === "schematic_port",
+  ) as any[]) {
+    const sourcePort = circuitJson.find(
+      (element: any) =>
+        element.type === "source_port" &&
+        element.source_port_id === schematicPort.source_port_id,
+    ) as any
+    const hints = [
+      sourcePort?.name,
+      sourcePort?.pin_number,
+      ...(sourcePort?.port_hints ?? []),
+    ]
+      .filter((hint) => hint !== undefined && hint !== null)
+      .map(String)
+    const pin =
+      hints
+        .map((hint) => pinByNumber.get(hint) ?? pinByName.get(hint))
+        .find(Boolean) ?? undefined
+    if (!pin) continue
+    schematicPort.center = { x: pin.at[0], y: -pin.at[1] }
+  }
+}
+
+export const addSchematicPropsToTscircuitCode = (
+  code: string,
+  props: KicadSymSchematicProps,
+) => {
+  if (Object.keys(props.schPinArrangement).length === 0) return code
+
+  const arrangement = JSON.stringify(props.schPinArrangement, null, "  ")
+  const propLine = `    schPinArrangement={${arrangement}}\n`
+
+  if (code.includes("schPinArrangement={")) return code
+  return code.replace(/(\s+\{\.\.\.props\})/, `\n${propLine}$1`)
+}
+
+const getSchematicSize = (pins: KicadSymPin[]) => {
+  if (pins.length === 0) return { width: 0, height: 0 }
+  const xs = pins.map((pin) => pin.at[0])
+  const ys = pins.map((pin) => pin.at[1])
+  return {
+    width: Math.max(2, Math.max(...xs) - Math.min(...xs)),
+    height: Math.max(2, Math.max(...ys) - Math.min(...ys)),
+  }
+}

--- a/src/site/App.tsx
+++ b/src/site/App.tsx
@@ -1,10 +1,16 @@
-import { useCallback, useState, useRef } from "react"
-import { useStore } from "./use-store"
-import { Download, FileSearch } from "lucide-react"
-import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import { createSnippetUrl } from "@tscircuit/create-snippet-url"
 import { CircuitJsonPreview } from "@tscircuit/runframe"
 import { convertCircuitJsonToTscircuit } from "circuit-json-to-tscircuit"
-import { createSnippetUrl } from "@tscircuit/create-snippet-url"
+import { Download, FileSearch } from "lucide-react"
+import { useCallback, useRef, useState } from "react"
+import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import {
+  addSchematicPropsToTscircuitCode,
+  applyKicadSymPropsToCircuitJson,
+  createCircuitJsonFromKicadSymProps,
+  parseKicadSymToSchematicProps,
+} from "src/parse-kicad-sym-to-sch-props"
+import { useStore } from "./use-store"
 
 export const App = () => {
   const [error, setError] = useState<string | null>(null)
@@ -19,14 +25,32 @@ export const App = () => {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const handleProcessAndViewFiles = useCallback(async () => {
-    if (!filesAdded.kicad_mod) {
-      setError("No KiCad Mod file added")
+    if (!filesAdded.kicad_mod && !filesAdded.kicad_sym) {
+      setError("No KiCad Mod or KiCad Sym file added")
       return
     }
     setError(null)
     let circuitJson: any
+    let schematicProps:
+      | ReturnType<typeof parseKicadSymToSchematicProps>
+      | undefined
+
+    if (filesAdded.kicad_sym) {
+      try {
+        schematicProps = parseKicadSymToSchematicProps(filesAdded.kicad_sym)
+      } catch (err: any) {
+        setError(`Error parsing KiCad Sym file: ${err.toString()}`)
+        return
+      }
+    }
+
     try {
-      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+      circuitJson = filesAdded.kicad_mod
+        ? await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+        : createCircuitJsonFromKicadSymProps(schematicProps!)
+      if (schematicProps) {
+        applyKicadSymPropsToCircuitJson(circuitJson, schematicProps)
+      }
       updateCircuitJson(circuitJson as any)
     } catch (err: any) {
       setError(`Error parsing KiCad Mod file: ${err.toString()}`)
@@ -35,9 +59,13 @@ export const App = () => {
 
     try {
       // Now we convert the circuit json to tscircuit
-      const tscircuit = convertCircuitJsonToTscircuit(circuitJson, {
+      let tscircuit = convertCircuitJsonToTscircuit(circuitJson, {
         componentName: "MyComponent",
+        pinLabels: schematicProps?.pinLabels,
       })
+      if (schematicProps) {
+        tscircuit = addSchematicPropsToTscircuitCode(tscircuit, schematicProps)
+      }
       updateTscircuitCode(tscircuit)
     } catch (err: any) {
       setError(
@@ -151,6 +179,16 @@ export const App = () => {
                 {filesAdded.kicad_mod ? "✅" : "❌"}
               </span>
               <span className="text-gray-300">KiCad Mod File</span>
+            </div>
+            <div className="flex items-center gap-2 bg-gray-800/50 p-3 rounded-md">
+              <span
+                className={
+                  filesAdded.kicad_sym ? "text-green-500" : "text-gray-500"
+                }
+              >
+                {filesAdded.kicad_sym ? "loaded" : "optional"}
+              </span>
+              <span className="text-gray-300">KiCad Sym File</span>
             </div>
           </div>
           <div className="flex justify-center items-center gap-2">

--- a/tests/kicad-sym-sch-props.test.ts
+++ b/tests/kicad-sym-sch-props.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "bun:test"
+import {
+  addSchematicPropsToTscircuitCode,
+  applyKicadSymPropsToCircuitJson,
+  createCircuitJsonFromKicadSymProps,
+  parseKicadSymToSchematicProps,
+} from "src/parse-kicad-sym-to-sch-props"
+
+const sampleKicadSym = `
+(kicad_symbol_lib
+  (version 20231120)
+  (generator "kicad_symbol_editor")
+  (symbol "Test:U2"
+    (property "Reference" "U" (at 0 5.08 0))
+    (symbol "U2_0_1"
+      (pin input line (at -5.08 2.54 0) (length 2.54)
+        (name "VCC" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27)))))
+      (pin output line (at 5.08 2.54 180) (length 2.54)
+        (name "OUT" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27)))))
+      (pin passive line (at 0 -5.08 90) (length 2.54)
+        (name "GND" (effects (font (size 1.27 1.27))))
+        (number "3" (effects (font (size 1.27 1.27)))))
+    )
+  )
+)
+`
+
+test("parses KiCad symbol pins into labels and schematic arrangement", () => {
+  const props = parseKicadSymToSchematicProps(sampleKicadSym)
+
+  expect(props.pinLabels).toEqual({
+    pin1: "VCC",
+    pin2: "OUT",
+    pin3: "GND",
+  })
+  expect(props.schPinArrangement).toEqual({
+    leftSide: { pins: ["pin1"], direction: "top-to-bottom" },
+    rightSide: { pins: ["pin2"], direction: "top-to-bottom" },
+    bottomSide: { pins: ["pin3"], direction: "left-to-right" },
+  })
+})
+
+test("creates schematic circuit json from KiCad symbol pins", () => {
+  const props = parseKicadSymToSchematicProps(sampleKicadSym)
+  const circuitJson = createCircuitJsonFromKicadSymProps(props) as any[]
+
+  expect(circuitJson.filter((elm) => elm.type === "source_port")).toHaveLength(
+    3,
+  )
+  expect(circuitJson.find((elm) => elm.pin_label === "VCC")).toBeTruthy()
+  expect(
+    circuitJson.find(
+      (elm) =>
+        elm.type === "schematic_port" && elm.source_port_id === "source_port_0",
+    )?.center,
+  ).toEqual({ x: -5.08, y: -2.54 })
+})
+
+test("applies KiCad symbol labels to existing circuit json and generated code", () => {
+  const props = parseKicadSymToSchematicProps(sampleKicadSym)
+  const circuitJson = [
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      name: "1",
+      port_hints: ["1"],
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "schematic_port_0",
+      source_port_id: "source_port_0",
+      center: { x: 0, y: 0 },
+    },
+  ] as any[]
+
+  applyKicadSymPropsToCircuitJson(circuitJson, props)
+  expect(circuitJson[0].pin_label).toBe("VCC")
+  expect(circuitJson[1].center).toEqual({ x: -5.08, y: -2.54 })
+
+  const code = addSchematicPropsToTscircuitCode(
+    `export const MyComponent = (props: ChipProps) => (
+  <chip
+    {...props}
+  />
+)`,
+    props,
+  )
+  expect(code).toContain("schPinArrangement")
+  expect(code).toContain('"pin1"')
+})


### PR DESCRIPTION
## Summary
- parse optional .kicad_sym files into pinLabels and schPinArrangement
- apply symbol pin metadata to the schematic circuit JSON preview
- allow symbol-only processing while preserving .kicad_mod-only behavior
- add focused tests for symbol parsing and applying schematic metadata

## Tests
- bun test tests/kicad-sym-sch-props.test.ts

Note: the repo bunfig preloads SVG snapshot helpers that load sharp; in this Windows environment sharp native install failed, so I temporarily disabled bunfig only while running this focused non-SVG test.

/claim #114