### PR TITLE
Add kicad_sym schematic metadata support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
+export {
+  applyKicadSymToCircuitJson,
+  parseKicadSymPins,
+  parseKicadSymToCircuitJson,
+} from "./parse-kicad-sym-to-circuit-json"
 export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"

--- a/src/parse-kicad-mod-to-circuit-json.ts
+++ b/src/parse-kicad-mod-to-circuit-json.ts
@@ -1,12 +1,15 @@
 import type { AnyCircuitElement } from "circuit-json"
-import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
 import { convertKicadJsonToTsCircuitSoup as convertKicadJsonToCircuitJson } from "./convert-kicad-json-to-tscircuit-soup"
+import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
+import { applyKicadSymToCircuitJson } from "./parse-kicad-sym-to-circuit-json"
 
 export const parseKicadModToCircuitJson = async (
   kicadMod: string,
+  kicadSym?: string,
 ): Promise<AnyCircuitElement[]> => {
   const kicadJson = parseKicadModToKicadJson(kicadMod)
 
   const circuitJson = await convertKicadJsonToCircuitJson(kicadJson)
+  if (kicadSym) return applyKicadSymToCircuitJson(circuitJson as any, kicadSym)
   return circuitJson as any
 }

--- a/src/parse-kicad-sym-to-circuit-json.ts
+++ b/src/parse-kicad-sym-to-circuit-json.ts
@@ -1,0 +1,169 @@
+import type { AnyCircuitElement } from "circuit-json"
+import parseSExpression from "s-expression"
+
+type KicadSymPin = {
+  number: string
+  name: string
+  at: [number, number, number]
+}
+
+type PinSide = "left_side" | "right_side" | "top_side" | "bottom_side"
+
+const unwrapValue = (value: any) => value?.valueOf?.() ?? value
+
+const getAttr = (row: any[], key: string) => {
+  const attr = row.find((item) => Array.isArray(item) && item[0] === key)
+  return attr?.slice(1)
+}
+
+const toNumber = (value: any) => Number.parseFloat(`${unwrapValue(value)}`)
+
+const collectPinRows = (node: any): any[][] => {
+  if (!Array.isArray(node)) return []
+  const own = node[0] === "pin" ? [node] : []
+  return own.concat(node.flatMap((child) => collectPinRows(child)))
+}
+
+const parsePin = (pinRow: any[]): KicadSymPin => {
+  const numberAttr = getAttr(pinRow, "number")
+  const nameAttr = getAttr(pinRow, "name")
+  const atAttr = getAttr(pinRow, "at")
+
+  return {
+    number: `${unwrapValue(numberAttr?.[0])}`,
+    name: `${unwrapValue(nameAttr?.[0])}`,
+    at: [
+      toNumber(atAttr?.[0]),
+      toNumber(atAttr?.[1]),
+      toNumber(atAttr?.[2] ?? 0),
+    ],
+  }
+}
+
+const normalizeDegrees = (degrees: number) => ((degrees % 360) + 360) % 360
+
+const getPinSide = (pin: KicadSymPin): PinSide => {
+  const rotation = normalizeDegrees(pin.at[2])
+  if (rotation === 0) return "left_side"
+  if (rotation === 180) return "right_side"
+  if (rotation === 90) return "bottom_side"
+  if (rotation === 270) return "top_side"
+  throw new Error(`Unsupported KiCad symbol pin rotation: ${pin.at[2]}`)
+}
+
+const sortPinsForSide = (side: PinSide, pins: KicadSymPin[]) => {
+  return [...pins].sort((a, b) => {
+    if (side === "left_side" || side === "right_side") return a.at[1] - b.at[1]
+    return a.at[0] - b.at[0]
+  })
+}
+
+export const parseKicadSymPins = (kicadSym: string): KicadSymPin[] => {
+  const parsed = parseSExpression(kicadSym)
+  const pins = collectPinRows(parsed).map(parsePin)
+  if (pins.length === 0) throw new Error("No pins found in KiCad symbol")
+  return pins
+}
+
+export const applyKicadSymToCircuitJson = (
+  circuitJson: AnyCircuitElement[],
+  kicadSym: string,
+): AnyCircuitElement[] => {
+  const pins = parseKicadSymPins(kicadSym)
+  const pinsByNumber = new Map(pins.map((pin) => [pin.number, pin]))
+  const portLabels = Object.fromEntries(
+    pins.map((pin) => [pin.number, pin.name]),
+  )
+  const pinsBySide: Record<PinSide, KicadSymPin[]> = {
+    left_side: [],
+    right_side: [],
+    top_side: [],
+    bottom_side: [],
+  }
+
+  for (const pin of pins) {
+    pinsBySide[getPinSide(pin)].push(pin)
+  }
+
+  const portArrangement = Object.fromEntries(
+    (Object.keys(pinsBySide) as PinSide[])
+      .map((side) => {
+        const sidePins = sortPinsForSide(side, pinsBySide[side])
+        if (sidePins.length === 0) return undefined
+        return [
+          side,
+          {
+            pins: sidePins.map((pin) => Number.parseInt(pin.number, 10)),
+          },
+        ]
+      })
+      .filter(Boolean) as Array<[PinSide, { pins: number[] }]>,
+  )
+
+  return circuitJson.map((element: any) => {
+    if (element.type === "schematic_component") {
+      return {
+        ...element,
+        port_arrangement: portArrangement,
+        port_labels: portLabels,
+      }
+    }
+
+    if (element.type !== "source_port") return element
+
+    const pin = pinsByNumber.get(`${element.pin_number ?? element.name}`)
+    if (!pin) return element
+
+    return {
+      ...element,
+      pin_label: pin.name,
+      port_hints: [`pin${pin.number}`, pin.name],
+    }
+  }) as AnyCircuitElement[]
+}
+
+export const parseKicadSymToCircuitJson = async (
+  kicadSym: string,
+): Promise<AnyCircuitElement[]> => {
+  const pins = parseKicadSymPins(kicadSym)
+  const sourceComponentId = "source_component_0"
+  const schematicComponentId = "schematic_component_0"
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: sourceComponentId,
+      supplier_part_numbers: {},
+    } as any,
+    {
+      type: "schematic_component",
+      schematic_component_id: schematicComponentId,
+      source_component_id: sourceComponentId,
+      center: { x: 0, y: 0 },
+      rotation: 0,
+      size: { width: 0, height: 0 },
+    } as any,
+  ]
+
+  let sourcePortId = 0
+  for (const pin of pins) {
+    const sourcePortIdForPin = `source_port_${sourcePortId++}`
+    circuitJson.push({
+      type: "source_port",
+      source_port_id: sourcePortIdForPin,
+      source_component_id: sourceComponentId,
+      name: pin.number,
+      port_hints: [`pin${pin.number}`, pin.name],
+      pin_number: Number.parseInt(pin.number, 10),
+      pin_label: pin.name,
+    } as any)
+    circuitJson.push({
+      type: "schematic_port",
+      schematic_port_id: `schematic_port_${sourcePortId++}`,
+      source_port_id: sourcePortIdForPin,
+      schematic_component_id: schematicComponentId,
+      center: { x: 0, y: 0 },
+    } as any)
+  }
+
+  return applyKicadSymToCircuitJson(circuitJson, kicadSym)
+}

--- a/src/site/App.tsx
+++ b/src/site/App.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useState, useRef } from "react"
-import { useStore } from "./use-store"
-import { Download, FileSearch } from "lucide-react"
-import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import { createSnippetUrl } from "@tscircuit/create-snippet-url"
 import { CircuitJsonPreview } from "@tscircuit/runframe"
 import { convertCircuitJsonToTscircuit } from "circuit-json-to-tscircuit"
-import { createSnippetUrl } from "@tscircuit/create-snippet-url"
+import { Download, FileSearch } from "lucide-react"
+import { useCallback, useRef, useState } from "react"
+import { parseKicadModToCircuitJson } from "src/parse-kicad-mod-to-circuit-json"
+import { parseKicadSymToCircuitJson } from "src/parse-kicad-sym-to-circuit-json"
+import { useStore } from "./use-store"
 
 export const App = () => {
   const [error, setError] = useState<string | null>(null)
@@ -19,14 +20,19 @@ export const App = () => {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const handleProcessAndViewFiles = useCallback(async () => {
-    if (!filesAdded.kicad_mod) {
-      setError("No KiCad Mod file added")
+    if (!filesAdded.kicad_mod && !filesAdded.kicad_sym) {
+      setError("No KiCad file added")
       return
     }
     setError(null)
     let circuitJson: any
     try {
-      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+      circuitJson = filesAdded.kicad_mod
+        ? await parseKicadModToCircuitJson(
+            filesAdded.kicad_mod,
+            filesAdded.kicad_sym,
+          )
+        : await parseKicadSymToCircuitJson(filesAdded.kicad_sym!)
       updateCircuitJson(circuitJson as any)
     } catch (err: any) {
       setError(`Error parsing KiCad Mod file: ${err.toString()}`)
@@ -151,6 +157,16 @@ export const App = () => {
                 {filesAdded.kicad_mod ? "✅" : "❌"}
               </span>
               <span className="text-gray-300">KiCad Mod File</span>
+            </div>
+            <div className="flex items-center gap-2 bg-gray-800/50 p-3 rounded-md">
+              <span
+                className={
+                  filesAdded.kicad_sym ? "text-green-500" : "text-red-500"
+                }
+              >
+                {filesAdded.kicad_sym ? "✅" : "❌"}
+              </span>
+              <span className="text-gray-300">KiCad Symbol File</span>
             </div>
           </div>
           <div className="flex justify-center items-center gap-2">

--- a/tests/kicad-symbol.test.ts
+++ b/tests/kicad-symbol.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { parseKicadModToCircuitJson, parseKicadSymToCircuitJson } from "src"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const simpleSymbol = `
+(kicad_symbol_lib
+  (version 20231120)
+  (generator "kicad_symbol_editor")
+  (symbol "Test:DirectionalPart"
+    (pin passive line (at -5.08 -2.54 0) (length 2.54)
+      (name "GND") (number "1"))
+    (pin input line (at 5.08 -2.54 180) (length 2.54)
+      (name "VIN") (number "2"))
+    (pin output line (at 0 -5.08 90) (length 2.54)
+      (name "OUT") (number "3"))
+    (pin passive line (at 0 5.08 270) (length 2.54)
+      (name "EN") (number "4"))
+  )
+)
+`
+
+test("parses kicad_sym into schematic port arrangement and labels", async () => {
+  const circuitJson = (await parseKicadSymToCircuitJson(simpleSymbol)) as any[]
+  const schematicComponent = circuitJson.find(
+    (element) => element.type === "schematic_component",
+  )
+
+  expect(schematicComponent.port_arrangement).toEqual({
+    left_side: { pins: [1] },
+    right_side: { pins: [2] },
+    bottom_side: { pins: [3] },
+    top_side: { pins: [4] },
+  })
+  expect(schematicComponent.port_labels).toEqual({
+    "1": "GND",
+    "2": "VIN",
+    "3": "OUT",
+    "4": "EN",
+  })
+
+  const sourcePort = circuitJson.find(
+    (element) => element.type === "source_port" && element.name === "2",
+  )
+  expect(sourcePort.pin_label).toBe("VIN")
+  expect(sourcePort.port_hints).toEqual(["pin2", "VIN"])
+})
+
+test("kicad_sym enriches kicad_mod schematic metadata", async () => {
+  const fixture = await getTestFixture()
+  const fileContent = await fixture.getKicadFile(
+    "JST_XH_B3B-XH-AM_1x03_P2.50mm_Vertical.kicad_mod",
+  )
+  const circuitJson = (await parseKicadModToCircuitJson(
+    fileContent,
+    simpleSymbol,
+  )) as any[]
+  const schematicComponent = circuitJson.find(
+    (element) => element.type === "schematic_component",
+  )
+
+  expect(schematicComponent.port_labels["1"]).toBe("GND")
+  expect(schematicComponent.port_arrangement.left_side.pins).toEqual([1])
+})


### PR DESCRIPTION
## Summary

/claim #114

Adds real `.kicad_sym` support for schematic metadata instead of only storing uploaded symbol files in the UI.

This PR:
- parses KiCad symbol pins from `.kicad_sym` files
- converts pin position/rotation into `schematic_component.port_arrangement`
- maps pin numbers to human-readable `schematic_component.port_labels`
- enriches `.kicad_mod` conversion when an optional symbol file is supplied
- supports symbol-only conversion through `parseKicadSymToCircuitJson`
- wires the site process path so `.kicad_sym` files are actually used

AI-assisted with Codex; I reviewed the diff and kept the change scoped to symbol metadata support.

## Verification

- `bun test`
- `npm run build:lib`
- `npm run build:site`
- `bunx biome check src/parse-kicad-sym-to-circuit-json.ts src/parse-kicad-mod-to-circuit-json.ts src/index.ts src/site/App.tsx tests/kicad-symbol.test.ts`