### PR TITLE
feat: add kicad_sym support for schematic pin arrangement

### DIFF
--- a/src/convert-kicad-json-to-tscircuit-soup.ts
+++ b/src/convert-kicad-json-to-tscircuit-soup.ts
@@ -1,4 +1,4 @@
-import type { KicadModJson } from "./kicad-zod"
+import type { KicadModJson, KicadSymJson } from "./kicad-zod"
 import type {
   AnyCircuitElement,
   PcbHole,
@@ -108,6 +108,7 @@ export const convertKicadLayerToTscircuitLayer = (kicadLayer: string) => {
 
 export const convertKicadJsonToTsCircuitSoup = async (
   kicadJson: KicadModJson,
+  kicadSym?: KicadSymJson | null,
 ): Promise<AnyCircuitElement[]> => {
   const {
     fp_lines,
@@ -129,13 +130,47 @@ export const convertKicadJsonToTsCircuitSoup = async (
     supplier_part_numbers: {},
   } as any)
 
+  const schPortArrangement: Record<string, { x: number; y: number }> = {}
+  if (kicadSym) {
+    const firstSymbol = kicadSym.symbols[0]
+    if (firstSymbol?.pins) {
+      for (const pin of firstSymbol.pins) {
+        const pinNum = pin.number
+        if (pinNum) {
+          schPortArrangement[pinNum] = {
+            x: pin.at[0],
+            y: -pin.at[1],
+          }
+        }
+      }
+    }
+  }
+
+  const symPins = kicadSym?.symbols[0]?.pins ?? []
+  const maxSymX = symPins.reduce(
+    (max, p) => Math.max(max, Math.abs(p.at[0])),
+    0,
+  )
+  const maxSymY = symPins.reduce(
+    (max, p) => Math.max(max, Math.abs(p.at[1])),
+    0,
+  )
+  const symSize =
+    symPins.length > 0
+      ? { width: maxSymX * 2 + 2, height: maxSymY * 2 + 2 }
+      : { width: 0, height: 0 }
+
   circuitJson.push({
     type: "schematic_component",
     schematic_component_id: "schematic_component_0",
     source_component_id: "source_component_0",
     center: { x: 0, y: 0 },
     rotation: 0,
-    size: { width: 0, height: 0 },
+    size: symSize,
+    sch_port_arrangement:
+      Object.keys(schPortArrangement).length > 0
+        ? schPortArrangement
+        : undefined,
   } as any)
 
   // Collect all unique port names from pads and holes
@@ -180,12 +215,15 @@ export const convertKicadJsonToTsCircuitSoup = async (
       pin_number: pinNumber,
       pin_label: pinNumber !== undefined ? `pin${pinNumber}` : undefined,
     } as any)
+    const pinNumStr = String(portName)
+    const symPinPos = schPortArrangement[pinNumStr]
+    const portCenter = symPinPos ?? { x: 0, y: 0 }
     circuitJson.push({
       type: "schematic_port",
       schematic_port_id: `schematic_port_${sourcePortId++}`,
       source_port_id,
       schematic_component_id: "schematic_component_0",
-      center: { x: 0, y: 0 },
+      center: portCenter,
     })
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
 export { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
-export { parseKicadModToCircuitJson } from "./parse-kicad-mod-to-circuit-json"
+export { parseKicadSymToKicadJson } from "./parse-kicad-sym-to-kicad-json"
+export {
+  parseKicadModToCircuitJson,
+  parseKicadSymToCircuitJson,
+} from "./parse-kicad-mod-to-circuit-json"
 export { convertKicadJsonToTsCircuitSoup } from "./convert-kicad-json-to-tscircuit-soup"
+export type { KicadModJson, KicadSymJson } from "./kicad-zod"

--- a/src/kicad-zod.ts
+++ b/src/kicad-zod.ts
@@ -280,6 +280,28 @@ export const kicad_mod_json_def = z.object({
   holes: z.array(hole_def).optional(),
 })
 
+export const sym_pin_def = z.object({
+  name: z.string(),
+  number: z.string(),
+  at: point,
+  electrical_type: z.string().optional(),
+  length: z.number().optional(),
+  rotation: z.number().optional(),
+})
+
+export const sym_symbol_def = z.object({
+  symbol_name: z.string(),
+  pins: z.array(sym_pin_def).optional(),
+  properties: z.array(property_def).optional(),
+})
+
+export const kicad_sym_json_def = z.object({
+  symbols: z.array(sym_symbol_def),
+  version: z.string().optional(),
+  generator: z.string().optional(),
+  generator_version: z.string().optional(),
+})
+
 export type Point2 = z.infer<typeof point2>
 export type Point3 = z.infer<typeof point3>
 export type Point = z.infer<typeof point>
@@ -295,3 +317,6 @@ export type FpArc = z.infer<typeof fp_arc_def>
 export type FpCircle = z.infer<typeof fp_circle_def>
 export type FpPoly = z.infer<typeof fp_poly_def>
 export type KicadModJson = z.infer<typeof kicad_mod_json_def>
+export type SymPin = z.infer<typeof sym_pin_def>
+export type SymSymbol = z.infer<typeof sym_symbol_def>
+export type KicadSymJson = z.infer<typeof kicad_sym_json_def>

--- a/src/parse-kicad-mod-to-circuit-json.ts
+++ b/src/parse-kicad-mod-to-circuit-json.ts
@@ -1,12 +1,38 @@
 import type { AnyCircuitElement } from "circuit-json"
 import { parseKicadModToKicadJson } from "./parse-kicad-mod-to-kicad-json"
+import { parseKicadSymToKicadJson } from "./parse-kicad-sym-to-kicad-json"
 import { convertKicadJsonToTsCircuitSoup as convertKicadJsonToCircuitJson } from "./convert-kicad-json-to-tscircuit-soup"
 
 export const parseKicadModToCircuitJson = async (
   kicadMod: string,
+  kicadSym?: string | null,
 ): Promise<AnyCircuitElement[]> => {
   const kicadJson = parseKicadModToKicadJson(kicadMod)
 
-  const circuitJson = await convertKicadJsonToCircuitJson(kicadJson)
+  let symJson = null
+  if (kicadSym) {
+    symJson = parseKicadSymToKicadJson(kicadSym)
+  }
+
+  const circuitJson = await convertKicadJsonToCircuitJson(kicadJson, symJson)
+  return circuitJson as any
+}
+
+export const parseKicadSymToCircuitJson = async (
+  kicadSym: string,
+): Promise<AnyCircuitElement[]> => {
+  const symJson = parseKicadSymToKicadJson(kicadSym)
+  const circuitJson = await convertKicadJsonToCircuitJson(
+    {
+      footprint_name: "symbol_only",
+      layer: "F.Cu",
+      properties: [],
+      fp_lines: [],
+      fp_texts: [],
+      fp_arcs: [],
+      pads: [],
+    } as any,
+    symJson,
+  )
   return circuitJson as any
 }

--- a/src/parse-kicad-sym-to-kicad-json.ts
+++ b/src/parse-kicad-sym-to-kicad-json.ts
@@ -1,0 +1,147 @@
+import parseSExpression from "s-expression"
+import {
+  type KicadSymJson,
+  type Property,
+  type SymPin,
+  type SymSymbol,
+  attributes_def,
+  kicad_sym_json_def,
+} from "./kicad-zod"
+import { formatAttr, getAttr } from "./get-attr"
+
+export const parseKicadSymToKicadJson = (fileContent: string): KicadSymJson => {
+  const kicadSExpr = parseSExpression(fileContent)
+
+  const libTop = kicadSExpr.slice(1)
+
+  const topLevelAttributes: any = {}
+  const symbols: SymSymbol[] = []
+
+  for (const row of libTop) {
+    if (!Array.isArray(row)) continue
+    const head = row[0]?.valueOf?.()
+
+    if (
+      head === "version" ||
+      head === "generator" ||
+      head === "generator_version"
+    ) {
+      topLevelAttributes[head] = row[1]?.valueOf?.()
+      continue
+    }
+
+    if (head === "symbol") {
+      const symbolName = row[1]?.valueOf?.()
+      const symbolBody = row.slice(2)
+
+      const properties: Property[] = []
+      const pins: SymPin[] = []
+
+      for (const symElement of symbolBody) {
+        if (!Array.isArray(symElement)) continue
+        const elHead = symElement[0]?.valueOf?.()
+
+        if (elHead === "property") {
+          const key = symElement[1]?.valueOf?.()
+          const val = symElement[2]?.valueOf?.()
+          const attributes = attributes_def.parse(
+            symElement.slice(3).reduce((acc: any, attrAr: any[]) => {
+              const attrKey = attrAr[0]?.valueOf?.()
+              if (attrKey) {
+                acc[attrKey] = formatAttr(attrAr.slice(1), attrKey)
+              }
+              return acc
+            }, {} as any),
+          )
+          properties.push({ key, val, attributes } as Property)
+          continue
+        }
+
+        if (elHead === "pin") {
+          const electricalType = symElement[1]?.valueOf?.()
+          const at = getAttr(symElement, "at")
+          const lengthVal = getAttr(symElement, "length")
+
+          let pinName = ""
+          let pinNumber = ""
+
+          for (const pinElem of symElement.slice(2)) {
+            if (!Array.isArray(pinElem)) continue
+            if (pinElem[0]?.valueOf?.() === "name") {
+              pinName = pinElem[1]?.valueOf?.() ?? ""
+            }
+            if (pinElem[0]?.valueOf?.() === "number") {
+              pinNumber = pinElem[1]?.valueOf?.() ?? ""
+            }
+          }
+
+          const atArr: [number, number, number] = Array.isArray(at)
+            ? [Number(at[0] ?? 0), Number(at[1] ?? 0), Number(at[2] ?? 0)]
+            : [0, 0, 0]
+
+          pins.push({
+            name: pinName,
+            number: pinNumber,
+            at: atArr,
+            electrical_type: electricalType,
+            length: typeof lengthVal === "number" ? lengthVal : undefined,
+            rotation: atArr[2],
+          })
+          continue
+        }
+
+        if (elHead === "symbol") {
+          const subSymbolName = symElement[1]?.valueOf?.()
+          const subSymbolBody = symElement.slice(2)
+
+          for (const subElement of subSymbolBody) {
+            if (!Array.isArray(subElement)) continue
+            const subHead = subElement[0]?.valueOf?.()
+
+            if (subHead === "pin") {
+              const at = getAttr(subElement, "at")
+              const lengthVal = getAttr(subElement, "length")
+
+              let pinName = ""
+              let pinNumber = ""
+
+              for (const pinElem of subElement.slice(1)) {
+                if (!Array.isArray(pinElem)) continue
+                if (pinElem[0]?.valueOf?.() === "name") {
+                  pinName = pinElem[1]?.valueOf?.() ?? ""
+                }
+                if (pinElem[0]?.valueOf?.() === "number") {
+                  pinNumber = pinElem[1]?.valueOf?.() ?? ""
+                }
+              }
+
+              const atArr: [number, number, number] = Array.isArray(at)
+                ? [Number(at[0] ?? 0), Number(at[1] ?? 0), Number(at[2] ?? 0)]
+                : [0, 0, 0]
+
+              pins.push({
+                name: pinName,
+                number: pinNumber,
+                at: atArr,
+                length: typeof lengthVal === "number" ? lengthVal : undefined,
+                rotation: atArr[2],
+              })
+            }
+          }
+          continue
+        }
+      }
+
+      symbols.push({
+        symbol_name: symbolName ?? "unnamed",
+        pins,
+        properties: properties.length > 0 ? properties : undefined,
+      })
+    }
+  }
+
+  return kicad_sym_json_def.parse({
+    symbols,
+    ...topLevelAttributes,
+  })
+}

--- a/src/site/App.tsx
+++ b/src/site/App.tsx
@@ -26,7 +26,10 @@ export const App = () => {
     setError(null)
     let circuitJson: any
     try {
-      circuitJson = await parseKicadModToCircuitJson(filesAdded.kicad_mod)
+      circuitJson = await parseKicadModToCircuitJson(
+        filesAdded.kicad_mod,
+        filesAdded.kicad_sym ?? null,
+      )
       updateCircuitJson(circuitJson as any)
     } catch (err: any) {
       setError(`Error parsing KiCad Mod file: ${err.toString()}`)


### PR DESCRIPTION
/claim #114

## Summary

Adds support for .kicad_sym files in the KiCad component converter.

### Changes
- Added Zod types for kicad_sym (SymPin, SymSymbol, KicadSymJson)
- Created parse-kicad-sym-to-kicad-json.ts parser for .kicad_sym S-expression files
- Updated convertKicadJsonToTsCircuitSoup to accept optional kicad_sym data
- Populates sch_port_arrangement on schematic components from symbol pin positions
- Positions schematic ports at correct coordinates from the symbol
- Exported new types and parseKicadSymToCircuitJson function
- Wired kicad_sym file support into the App.tsx UI

### How it works
When a .kicad_sym file is provided alongside a .kicad_mod file, the converter extracts pin information (names, numbers, positions) and maps them into the circuit JSON schematic component with sch_port_arrangement. This enables proper schematic visualization.